### PR TITLE
Provide stable compare to Impulse in useImpulse

### DIFF
--- a/.changeset/yellow-bats-exercise.md
+++ b/.changeset/yellow-bats-exercise.md
@@ -1,0 +1,5 @@
+---
+"react-impulse": patch
+---
+
+🐛 bugfix: an `Impulse` created via `useImpulse` uses latest `compare` function provided to `useImpulse` but not only the initial one.

--- a/src/Impulse.ts
+++ b/src/Impulse.ts
@@ -1,4 +1,4 @@
-import { Compare, isEqual, isFunction, noop } from "./utils"
+import { Compare, eq, isFunction, noop } from "./utils"
 import { WatchContext } from "./WatchContext"
 import { SetValueContext } from "./SetValueContext"
 import {
@@ -23,7 +23,7 @@ export class Impulse<T> {
   ): Impulse<T> {
     WatchContext.warning(WARNING_MESSAGE_CALLING_OF_WHEN_WATCHING)
 
-    return new Impulse(initialValue, compare ?? isEqual)
+    return new Impulse(initialValue, compare ?? eq)
   }
 
   /**
@@ -85,7 +85,7 @@ export class Impulse<T> {
 
     return new Impulse(
       isFunction(transform) ? transform(this.value) : this.value,
-      compare ?? isEqual,
+      compare ?? eq,
     )
   }
 
@@ -128,7 +128,7 @@ export class Impulse<T> {
       return
     }
 
-    const finalCompare = compare ?? isEqual
+    const finalCompare = compare ?? eq
     const [emit, register] = SetValueContext.registerStoreSubscribers()
 
     const nextValue = isFunction(valueOrTransform)

--- a/src/useImpulse.ts
+++ b/src/useImpulse.ts
@@ -1,7 +1,5 @@
-import { useState } from "react"
-
 import { Impulse } from "./Impulse"
-import { Compare, isFunction } from "./utils"
+import { Compare, isFunction, usePermanent, useEvent, eq } from "./utils"
 
 /**
  * A hook that initiates a stable (never changing) Impulse.
@@ -17,13 +15,13 @@ export function useImpulse<T>(
   valueOrLazyValue: T | ((...args: []) => T),
   compare?: null | Compare<T>,
 ): Impulse<T> {
-  const [impulse] = useState(() => {
+  const stableCompare = useEvent(compare ?? eq)
+
+  return usePermanent(() => {
     const initialValue = isFunction(valueOrLazyValue)
       ? valueOrLazyValue()
       : valueOrLazyValue
 
-    return Impulse.of(initialValue, compare)
+    return Impulse.of(initialValue, stableCompare)
   })
-
-  return impulse
 }

--- a/src/useWatchImpulse.ts
+++ b/src/useWatchImpulse.ts
@@ -1,8 +1,8 @@
-import { useCallback, useDebugValue, useEffect, useRef } from "react"
+import { useCallback, useDebugValue } from "react"
 import { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/with-selector.js"
 
 import { useWatchContext } from "./useWatchContext"
-import { Compare, isEqual } from "./utils"
+import { Compare, eq, useEvent } from "./utils"
 
 /**
  * A hook that executes the `watcher` function whenever any of the involved Impulses' values update
@@ -27,25 +27,12 @@ export function useWatchImpulse<T>(
     [executeWatcher, watcher],
   )
 
-  // changeling of the `compare` value should not trigger `useSyncExternalStoreWithSelector`
-  // to re-select the impulse's value
-  const compareRef = useRef(compare ?? isEqual)
-  useEffect(() => {
-    compareRef.current = compare ?? isEqual
-  }, [compare])
-
-  // it should memoize the onCompare otherwise it will call the watcher on each render
-  const onCompare: Compare<T> = useCallback(
-    (left, right) => compareRef.current(left, right),
-    [],
-  )
-
   const value = useSyncExternalStoreWithSelector(
     subscribe,
     getVersion,
     getVersion,
     select,
-    onCompare,
+    useEvent(compare ?? eq),
   )
 
   useDebugValue(value)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,11 @@
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useCallback,
+  useState,
+} from "react"
+
 /**
  * A function that compares two values and returns `true` if they are equal.
  * Depending on the type of the values it might be reasonable to use
@@ -10,19 +18,38 @@ export type Compare<T> = (left: T, right: T) => boolean
 /**
  * @private
  */
-export const isEqual: Compare<unknown> = Object.is
+export const eq: Compare<unknown> = Object.is
 
 /**
  * @private
  */
-export const noop: VoidFunction = () => {
+export function noop(): void {
   // do nothing
 }
 
-export const isFunction = <
+export function isFunction<
   TFunction extends (...args: Array<never>) => unknown,
->(
-  anything: unknown,
-): anything is TFunction => {
+>(anything: unknown): anything is TFunction {
   return typeof anything === "function"
+}
+
+export const useIsomorphicEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect
+
+export function useEvent<TArgs extends ReadonlyArray<unknown>, TResult>(
+  handler: (...args: TArgs) => TResult,
+): (...args: TArgs) => TResult {
+  const handlerRef = useRef<(...args: TArgs) => TResult>()
+
+  useIsomorphicEffect(() => {
+    handlerRef.current = handler
+  })
+
+  return useCallback((...args: TArgs) => handlerRef.current!(...args), [])
+}
+
+export function usePermanent<TValue>(init: () => TValue): TValue {
+  const [value] = useState(init)
+
+  return value
 }

--- a/tests/Impulse.spec.ts
+++ b/tests/Impulse.spec.ts
@@ -1,20 +1,20 @@
 import { Impulse } from "../src"
-import { isEqual } from "../src/utils"
+import { eq } from "../src/utils"
 
 import { Counter } from "./common"
 
 describe("Impulse#compare", () => {
   describe("when creating a impulse with Impulse.of", () => {
-    it.concurrent("assigns isEqual by default", () => {
+    it.concurrent("assigns eq by default", () => {
       const impulse = Impulse.of({ count: 0 })
 
-      expect(impulse.compare).toBe(isEqual)
+      expect(impulse.compare).toBe(eq)
     })
 
-    it.concurrent("assigns isEqual by `null`", () => {
+    it.concurrent("assigns eq by `null`", () => {
       const impulse = Impulse.of({ count: 0 }, null)
 
-      expect(impulse.compare).toBe(isEqual)
+      expect(impulse.compare).toBe(eq)
     })
 
     it.concurrent("assigns custom function", () => {
@@ -29,7 +29,7 @@ describe("Impulse#compare", () => {
       const impulse = Impulse.of({ count: 0 })
 
       expect(impulse.clone().compare).toBe(impulse.compare)
-      expect(impulse.clone().compare).toBe(isEqual)
+      expect(impulse.clone().compare).toBe(eq)
     })
 
     it.concurrent("inherits custom the source impulse compare", () => {
@@ -39,10 +39,10 @@ describe("Impulse#compare", () => {
       expect(impulse.clone().compare).toBe(Counter.compare)
     })
 
-    it.concurrent("assigns isEqual by `null`", () => {
+    it.concurrent("assigns eq by `null`", () => {
       const impulse = Impulse.of({ count: 0 }, Counter.compare)
 
-      expect(impulse.clone(Counter.clone, null).compare).toBe(isEqual)
+      expect(impulse.clone(Counter.clone, null).compare).toBe(eq)
     })
 
     it.concurrent("assigns custom function", () => {
@@ -63,7 +63,7 @@ describe("Impulse#compare", () => {
       expect(impulse.getValue()).toBe(initial)
     })
 
-    it.concurrent("replaces with isEqual when `null`", () => {
+    it.concurrent("replaces with eq when `null`", () => {
       const initial = { count: 0 }
       const impulse = Impulse.of(initial, Counter.compare)
 

--- a/tests/illegal-usage.spec.tsx
+++ b/tests/illegal-usage.spec.tsx
@@ -9,15 +9,16 @@ import {
   useImpulseMemo,
   useWatchImpulse,
   watch,
-} from "../../src"
+} from "../src"
 import {
   WARNING_MESSAGE_CALLING_OF_WHEN_WATCHING,
   WARNING_MESSAGE_CALLING_CLONE_WHEN_WATCHING,
   WARNING_MESSAGE_CALLING_SET_VALUE_WHEN_WATCHING,
   WARNING_MESSAGE_CALLING_SUBSCRIBE_WHEN_WATCHING,
-} from "../../src/validation"
-import { noop } from "../../src/utils"
-import { WithImpulse, WithListener } from "../common"
+} from "../src/validation"
+import { noop, usePermanent } from "../src/utils"
+
+import { WithImpulse, WithListener } from "./common"
 
 const console$error = vi
   .spyOn(console, "error")
@@ -100,7 +101,7 @@ describe("calling Impulse.of()", () => {
 
   it.concurrent("fine when called inside watch()", () => {
     const Component = watch(() => {
-      const [state] = React.useState(Impulse.of(20))
+      const state = usePermanent(() => Impulse.of(20))
 
       return <div data-testid="count">{state.getValue()}</div>
     })
@@ -198,7 +199,7 @@ describe("calling Impulse#clone()", () => {
     const Component = watch<{
       impulse: Impulse<number>
     }>(({ impulse }) => {
-      const [state] = React.useState(impulse.clone())
+      const state = usePermanent(() => impulse.clone())
 
       return <div data-testid="count">{state.getValue()}</div>
     })

--- a/tests/useImpulse.spec.ts
+++ b/tests/useImpulse.spec.ts
@@ -1,9 +1,10 @@
-import { renderHook } from "@testing-library/react"
+import { act, renderHook } from "@testing-library/react"
 
-import { useImpulse } from "../src"
+import { Compare, useImpulse } from "../src"
+import * as utils from "../src/utils"
 
 describe("with direct initial value", () => {
-  it.concurrent("creates a impulse with an initial value", () => {
+  it.concurrent("creates an impulse with an initial value", () => {
     const initial = { count: 0 }
 
     const { result } = renderHook(() => useImpulse(initial))
@@ -110,21 +111,86 @@ describe("with lazy initial value", () => {
 
 describe("with compare function", () => {
   it.concurrent("applies Object.is by default", () => {
-    const { result } = renderHook(() => useImpulse({ count: 0 }))
+    const spy_eq = vi.spyOn(utils, "eq")
+    const { result } = renderHook(() => useImpulse(0))
 
-    expect(result.current.compare).toBe(Object.is)
+    expect(spy_eq).not.toHaveBeenCalled()
+
+    act(() => {
+      result.current.setValue((x) => x + 1)
+    })
+
+    expect(spy_eq).toHaveBeenCalledOnce()
+    expect(spy_eq).toHaveBeenLastCalledWith(0, 1)
   })
 
   it.concurrent("applies Object.is when passing null as compare", () => {
-    const { result } = renderHook(() => useImpulse({ count: 0 }, null))
+    const spy_eq = vi.spyOn(utils, "eq")
+    const { result } = renderHook(() => useImpulse(0, null))
 
-    expect(result.current.compare).toBe(Object.is)
+    expect(spy_eq).not.toHaveBeenCalled()
+
+    act(() => {
+      result.current.setValue((x) => x + 1)
+    })
+
+    expect(spy_eq).toHaveBeenCalledOnce()
+    expect(spy_eq).toHaveBeenLastCalledWith(0, 1)
+  })
+
+  it.concurrent("does not call the function on init", () => {
+    const compare = vi.fn()
+    renderHook(() => useImpulse({ count: 0 }, compare))
+
+    expect(compare).not.toHaveBeenCalled()
   })
 
   it.concurrent("passes custom compare function", () => {
-    const compare = vi.fn()
-    const { result } = renderHook(() => useImpulse({ count: 0 }, compare))
+    const compare = vi.fn<[number], boolean>()
+    const { result } = renderHook(() => useImpulse<number>(0, compare))
 
-    expect(result.current.compare).toBe(compare)
+    act(() => {
+      result.current.setValue(1)
+    })
+
+    expect(compare).toHaveBeenCalledOnce()
+    expect(compare).toHaveBeenLastCalledWith(0, 1)
+  })
+
+  it.concurrent("updates compare function on re-render", () => {
+    const compare_1 = vi.fn().mockImplementation(Object.is)
+    const compare_2 = vi.fn().mockImplementation(Object.is)
+    const spy_eq = vi.spyOn(utils, "eq")
+
+    const { result, rerender } = renderHook(
+      (compare: null | Compare<number>) => useImpulse<number>(0, compare),
+      {
+        initialProps: compare_1,
+      },
+    )
+
+    act(() => {
+      result.current.setValue((x) => x + 1)
+    })
+    expect(compare_1).toHaveBeenCalledOnce()
+    expect(compare_1).toHaveBeenLastCalledWith(0, 1)
+    vi.clearAllMocks()
+
+    rerender(compare_2)
+    act(() => {
+      result.current.setValue((x) => x + 1)
+    })
+    expect(compare_1).not.toHaveBeenCalled()
+    expect(compare_2).toHaveBeenCalledOnce()
+    expect(compare_2).toHaveBeenLastCalledWith(1, 2)
+    vi.clearAllMocks()
+
+    rerender(null)
+    act(() => {
+      result.current.setValue((x) => x + 1)
+    })
+    expect(compare_2).not.toHaveBeenCalled()
+    expect(spy_eq).toHaveBeenCalledOnce()
+    expect(spy_eq).toHaveBeenLastCalledWith(2, 3)
   })
 })

--- a/tests/useWatchImpulse/watcher-comparator.spec.ts
+++ b/tests/useWatchImpulse/watcher-comparator.spec.ts
@@ -3,7 +3,7 @@ import { act, renderHook } from "@testing-library/react"
 
 import { Impulse, useWatchImpulse } from "../../src"
 import { Counter, WithCompare, WithImpulse } from "../common"
-import { Compare, isEqual } from "../../src/utils"
+import { Compare, eq } from "../../src/utils"
 
 describe.each([
   [
@@ -54,7 +54,7 @@ describe.each([
 
       rerender({
         impulse,
-        compare: isEqual,
+        compare: eq,
       })
       expect(result.current).toBe(initial)
 


### PR DESCRIPTION
The changes fix the following use case:

```ts
const [compare, setCompare] = useState(Object.is)
const impulse = useImpulse({ count: 0 }, compare)

useEffect(() => {
	setCompare(() => {
  		return (left, right) => left.count === right.count
	})
}, [])
```

In the code snipped above the `impulse` will always have `Object.is` as a comparator, but in fact it should have the custom one changed inside the `useEffect`. This is what the changes target to fix.