### PR TITLE
Build the source code before publishing

### DIFF
--- a/.changeset/dull-berries-wait.md
+++ b/.changeset/dull-berries-wait.md
@@ -1,0 +1,5 @@
+---
+"react-impulse": patch
+---
+
+🐛 bugfix: build the source code before publishing. It runs `pnpm run publish` instead of `pnpm publish` so it runs the custom script, that builds the package first and then uses `changesets publish`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,8 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm run publish
-          commit: Release ${{ steps.old-version.outputs.propStr }} -> ${{ steps.new-version.outputs.propStr }}
-          title: Release ${{ steps.old-version.outputs.propStr }} -> ${{ steps.new-version.outputs.propStr }}
+          commit: Release `${{ steps.old-version.outputs.prop }}` -> `${{ steps.new-version.outputs.prop }}`
+          title: Release `${{ steps.old-version.outputs.prop }}` -> `${{ steps.new-version.outputs.prop }}`
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1
         with:
-          publish: pnpm publish
+          publish: pnpm run publish
           commit: Release ${{ steps.old-version.outputs.propStr }} -> ${{ steps.new-version.outputs.propStr }}
           title: Release ${{ steps.old-version.outputs.propStr }} -> ${{ steps.new-version.outputs.propStr }}
         env:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "build": "tsup src/index.ts --dts --sourcemap --format=esm,cjs --clean --env.NODE_ENV=production",
+    "build": "tsup src/index.ts --dts --sourcemap --format=esm,cjs --clean",
     "pretest": "node ./print-react-version",
     "test": "vitest --single-thread",
     "test:run": "pnpm test -- --run --reporter=dot",


### PR DESCRIPTION
It runs `pnpm run publish` instead of `pnpm publish` so it runs the custom script, that builds the package first and then uses `changesets publish`.