### PR TITLE
Run Release on push

### DIFF
--- a/.github/actions/run-checks/action.yml
+++ b/.github/actions/run-checks/action.yml
@@ -1,0 +1,33 @@
+name: Run checks
+
+runs:
+  using: composite
+  steps:
+    - name: Type check
+      if: ${{ always() }}
+      run: pnpm typecheck
+
+    - name: Lint
+      if: ${{ always() }}
+      run: pnpm lint
+
+    - name: Test against React 18
+      if: ${{ always() }}
+      run: pnpm test:run -- --coverage
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        fail_ci_if_error: false
+
+    - name: Install React 17 and legacy testing libraries
+      run: pnpm add -D react@17 @testing-library/react@12  @testing-library/react-hooks@7
+
+    - name: Test against React 17
+      run: pnpm test:run
+
+    - name: Install React 16
+      run: pnpm add -D react@16
+
+    - name: Test against React 16
+      run: pnpm test:run

--- a/.github/actions/run-checks/action.yml
+++ b/.github/actions/run-checks/action.yml
@@ -5,14 +5,17 @@ runs:
   steps:
     - name: Type check
       if: ${{ always() }}
+      shell: bash
       run: pnpm typecheck
 
     - name: Lint
       if: ${{ always() }}
+      shell: bash
       run: pnpm lint
 
     - name: Test against React 18
       if: ${{ always() }}
+      shell: bash
       run: pnpm test:run -- --coverage
 
     - name: Upload coverage to Codecov
@@ -21,13 +24,17 @@ runs:
         fail_ci_if_error: false
 
     - name: Install React 17 and legacy testing libraries
+      shell: bash
       run: pnpm add -D react@17 @testing-library/react@12  @testing-library/react-hooks@7
 
     - name: Test against React 17
+      shell: bash
       run: pnpm test:run
 
     - name: Install React 16
+      shell: bash
       run: pnpm add -D react@16
 
     - name: Test against React 16
+      shell: bash
       run: pnpm test:run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/setup-env
-      - uses: ./.github/actions/run-checks
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+
+      - name: Run checks
+        uses: ./.github/actions/run-checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 
 on:
   pull_request:
-    paths:
-      - "!**.md"
+    paths-ignore:
+      - "**.md"
 
 env:
   CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,6 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches:
-      - master
-      - v*.x
-      - v*.*.x
 
 env:
   CI: true
@@ -20,34 +15,5 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup env
-        uses: ./.github/actions/setup-env
-
-      - name: Type check
-        if: ${{ always() }}
-        run: pnpm typecheck
-
-      - name: Lint
-        if: ${{ always() }}
-        run: pnpm lint
-
-      - name: Test against React 18
-        if: ${{ always() }}
-        run: pnpm test:run -- --coverage
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: false
-
-      - name: Install React 17 and legacy testing libraries
-        run: pnpm add -D react@17 @testing-library/react@12  @testing-library/react-hooks@7
-
-      - name: Test against React 17
-        run: pnpm test:run
-
-      - name: Install React 16
-        run: pnpm add -D react@16
-
-      - name: Test against React 16
-        run: pnpm test:run
+      - uses: ./.github/actions/setup-env
+      - uses: ./.github/actions/run-checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+    paths:
+      - "!**.md"
 
 env:
   CI: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,11 @@
 name: Release
 
 on:
-  workflow_run:
-    types:
-      - completed
-    workflows:
-      - CI
+  push:
     branches:
       - master
-      - v*.x
-      - v*.*.x
+      - v[0-9]+.x
+      - v[0-9]+.[0-9]+.x
 
 env:
   CI: true
@@ -20,21 +16,18 @@ jobs:
   release:
     name: Release on npm
     runs-on: ubuntu-latest
-    # prevents this action from running either on failed CI or on forks
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'owanturist' }}
+    # prevents this action from running on forks
+    if: ${{ github.repository_owner == 'owanturist' }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          # This checkouts to the branch triggered the CI workflow
-          ref: ${{ github.event.workflow_run.head_branch }}
-
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Setup env
-        uses: ./.github/actions/setup-env
+      - uses: ./.github/actions/setup-env
+      - uses: ./.github/actions/run-checks
 
       - name: Get changeset status
         run: pnpm cs status --output ./changeset-status.json
@@ -57,7 +50,7 @@ jobs:
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1
         with:
-          publish: pnpm run publish --tag=${{ github.event.workflow_run.head_branch == 'master' && 'latest' || '' }}
+          publish: pnpm run publish --tag=${{ github.ref_name == 'master' && 'latest' || '' }}
           commit: Release `${{ steps.old-version.outputs.prop }}` -> `${{ steps.new-version.outputs.prop }}`
           title: Release `${{ steps.old-version.outputs.prop }}` -> `${{ steps.new-version.outputs.prop }}`
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,11 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - uses: ./.github/actions/setup-env
-      - uses: ./.github/actions/run-checks
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+
+      - name: Run checks
+        uses: ./.github/actions/run-checks
 
       - name: Get changeset status
         run: pnpm cs status --output ./changeset-status.json


### PR DESCRIPTION
Split the run-checks action and use it in both CI and Release workflows, so Release does not depend anymore on the CI