### PR TITLE
Test against dist files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -274,7 +274,18 @@
         "jest/no-commented-out-tests": "error",
         "jest/consistent-test-it": ["error", { "fn": "it" }],
         "@typescript-eslint/explicit-function-return-type": "off",
-        "no-undefined": "off"
+        "no-undefined": "off",
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": ["../src/*"],
+                "message": "Import only ../src for tests"
+              }
+            ]
+          }
+        ]
       }
     }
   ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           fail_ci_if_error: false
 
   test-dist:
-    name: Run tests against built files
+    name: Run tests against dist files
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -98,7 +98,7 @@ jobs:
         run: pnpm test:run
 
   test-legacy:
-    name: Run tests against legacy build
+    name: Run tests against legacy React
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -114,7 +114,7 @@ jobs:
       - name: Install React 17 and legacy testing libraries
         run: pnpm add -D react@${{ matrix.version }} react-dom@${{ matrix.version }} @testing-library/react@12 @testing-library/react-hooks
 
-      - name: Test against React ${{ matrix.version }}
+      - name: Test against React@${{ matrix.version }}
         run: pnpm test:run
 
   size-limit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,16 +68,53 @@ jobs:
         with:
           fail_ci_if_error: false
 
-      - name: Install React 17 and legacy testing libraries
-        run: pnpm add -D react@17.0.0 react-dom@17.0.0 @testing-library/react@12 @testing-library/react-hooks
+  test-dist:
+    name: Run tests against built files
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        filename: [dist/index.js, dist/index.cjs]
 
-      - name: Test against React 17
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+
+      - name: Build
+        run: pnpm build
+
+      - name: Cleanup src folder
+        run: rm -rf src/*
+
+      - name: Create a symlink to the built file from src folder
+        # [s] - symbolic
+        # [F] - force, remove existing destination files
+        # [f] - unlink file if it already exists
+        run: cd src && ln -sFf ${{ matrix.filename }} src/index.js && cd ..
+
+      - name: Test
         run: pnpm test:run
 
-      - name: Install React 16
-        run: pnpm add -D react@16.12.0 react-dom@16.12.0
+  test-legacy:
+    name: Run tests against legacy build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [16.12.0, 17.0.0]
 
-      - name: Test against React 16
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+
+      - name: Install React 17 and legacy testing libraries
+        run: pnpm add -D react@${{ matrix.version }} react-dom@${{ matrix.version }} @testing-library/react@12 @testing-library/react-hooks
+
+      - name: Test against React ${{ matrix.version }}
         run: pnpm test:run
 
   size-limit:
@@ -102,7 +139,7 @@ jobs:
   release:
     name: Release on npm
     runs-on: ubuntu-latest
-    needs: checks
+    needs: [checks, test-dist, test-legacy]
     # prevents this action from running on forks and only on pushes
     if: ${{ github.repository_owner == 'owanturist' && github.event_name == 'push' }}
     concurrency: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        filename: [dist/index.js, dist/index.cjs]
+        filename: [index.js, index.cjs]
 
     steps:
       - name: Checkout repository
@@ -92,7 +92,7 @@ jobs:
         # [s] - symbolic
         # [F] - force, remove existing destination files
         # [f] - unlink file if it already exists
-        run: cd src && ln -sFf ${{ matrix.filename }} src/index.js && cd ..
+        run: cd src && ln -sFf ../dist/${{ matrix.filename }} index.js && cd ..
 
       - name: Test
         run: pnpm test:run

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -2,5 +2,7 @@ import type { TestingLibraryMatchers } from "@testing-library/jest-dom/matchers"
 
 declare module "vitest" {
   export interface JestAssertion<R = any>
-    extends TestingLibraryMatchers<typeof expect.stringContaining, R> {}
+    extends TestingLibraryMatchers<typeof expect.stringContaining, R> {
+    toHaveEmittersSize(size: number): R
+  }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "preinstall": "npx only-allow pnpm",
     "size": "size-limit",
     "build": "tsup",
-    "build:minified": "pnpm build --env.NODE_ENV production --minify=terser",
+    "build:minified": "pnpm build --env.NODE_ENV=production --minify=terser",
     "test": "node ./print-react-version && vitest --single-thread",
     "test:run": "pnpm test -- --run --reporter=dot",
     "lint": "eslint . --ext=js,jsx,ts,tsx",

--- a/setup-tests.ts
+++ b/setup-tests.ts
@@ -51,8 +51,8 @@ expect.extend({
       }
     }
 
-    // @ts-expect-error emitters field is mangled to "__" during build, see ./tsup.config
-    const emitters = received["emitters"] ?? received["__"] // eslint-disable-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/dot-notation
+    // @ts-expect-error emitters field is mangled to "$" during build, see ./tsup.config
+    const emitters = received["emitters"] ?? received["$"] // eslint-disable-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/dot-notation
 
     return {
       pass: emitters.size === size,

--- a/setup-tests.ts
+++ b/setup-tests.ts
@@ -56,8 +56,8 @@ const getImpulseEmitters = (input: unknown): null | Set<unknown> => {
     return null
   }
 
-  if ("emitters" in input && isSet(input.emitters)) {
-    return input.emitters
+  if ("_emitters" in input && isSet(input._emitters)) {
+    return input._emitters
   }
 
   if ("$" in input && isSet(input.$)) {

--- a/setup-tests.ts
+++ b/setup-tests.ts
@@ -5,10 +5,8 @@
 import "@testing-library/jest-dom/extend-expect"
 import { cleanup } from "@testing-library/react"
 
-// import { Impulse } from "./src"
-
 // forces tests to fail in case of illegal usage
-const console$error = vi
+const spy_console$error = vi
   .spyOn(console, "error")
   .mockImplementation((message: string) => {
     expect.fail(message)
@@ -26,7 +24,7 @@ afterEach(() => {
 })
 
 afterAll(() => {
-  console$error.mockRestore()
+  spy_console$error.mockRestore()
 })
 
 vi.mock("@testing-library/react", async () => {

--- a/src/Impulse.ts
+++ b/src/Impulse.ts
@@ -38,10 +38,10 @@ export class Impulse<T> {
 
   // Implements 👆
   @validate
-    .when("subscribe", SUBSCRIBE_CALLING_IMPULSE_OF)
-    .when("useWatchImpulse", USE_WATCH_IMPULSE_CALLING_IMPULSE_OF)
-    .when("useImpulseMemo", USE_IMPULSE_MEMO_CALLING_IMPULSE_OF)
-    .alert()
+    ._when("subscribe", SUBSCRIBE_CALLING_IMPULSE_OF)
+    ._when("useWatchImpulse", USE_WATCH_IMPULSE_CALLING_IMPULSE_OF)
+    ._when("useImpulseMemo", USE_IMPULSE_MEMO_CALLING_IMPULSE_OF)
+    ._alert()
 
   /**
    * Creates new Impulse.
@@ -58,12 +58,7 @@ export class Impulse<T> {
     return new Impulse(initialValue, compare ?? eq)
   }
 
-  /*@__MANGLE_PROP__*/
-  private readonly emitters = new Set<ScopeEmitter>()
-
-  // assigning the initial value is necessary for mangling
-  /*@__MANGLE_PROP__*/
-  private value: T = null as never
+  private readonly _emitters = new Set<ScopeEmitter>()
 
   /**
    * The `Compare` function compares Impulse's value with the new value given via `Impulse#setValue`.
@@ -73,8 +68,7 @@ export class Impulse<T> {
    */
   public readonly compare: Compare<T>
 
-  private constructor(initialValue: T, compare: Compare<T>) {
-    this.value = initialValue
+  private constructor(private _value: T, compare: Compare<T>) {
     this.compare = compare
   }
 
@@ -102,10 +96,10 @@ export class Impulse<T> {
   }
 
   @validate
-    .when("subscribe", SUBSCRIBE_CALLING_IMPULSE_CLONE)
-    .when("useWatchImpulse", USE_WATCH_IMPULSE_CALLING_IMPULSE_CLONE)
-    .when("useImpulseMemo", USE_IMPULSE_MEMO_CALLING_IMPULSE_CLONE)
-    .alert()
+    ._when("subscribe", SUBSCRIBE_CALLING_IMPULSE_CLONE)
+    ._when("useWatchImpulse", USE_WATCH_IMPULSE_CALLING_IMPULSE_CLONE)
+    ._when("useImpulseMemo", USE_IMPULSE_MEMO_CALLING_IMPULSE_CLONE)
+    ._alert()
   /**
    * Clones an Impulse.
    *
@@ -119,7 +113,7 @@ export class Impulse<T> {
     compare: null | Compare<T> = this.compare,
   ): Impulse<T> {
     return new Impulse(
-      isFunction(transform) ? transform(this.value) : this.value,
+      isFunction(transform) ? transform(this._value) : this._value,
       compare ?? eq,
     )
   }
@@ -149,16 +143,16 @@ export class Impulse<T> {
   public getValue<R>(select?: (value: T) => R): T | R {
     const scope = extractScope()
 
-    scope[EMITTER_KEY]?.attachTo(this.emitters)
+    scope[EMITTER_KEY]?._attachTo(this._emitters)
 
-    return isFunction(select) ? select(this.value) : this.value
+    return isFunction(select) ? select(this._value) : this._value
   }
 
   @validate
-    .when("watch", WATCH_CALLING_IMPULSE_SET_VALUE)
-    .when("useWatchImpulse", USE_WATCH_IMPULSE_CALLING_IMPULSE_SET_VALUE)
-    .when("useImpulseMemo", USE_IMPULSE_MEMO_CALLING_IMPULSE_SET_VALUE)
-    .prevent()
+    ._when("watch", WATCH_CALLING_IMPULSE_SET_VALUE)
+    ._when("useWatchImpulse", USE_WATCH_IMPULSE_CALLING_IMPULSE_SET_VALUE)
+    ._when("useImpulseMemo", USE_IMPULSE_MEMO_CALLING_IMPULSE_SET_VALUE)
+    ._prevent()
   /**
    * Updates the value.
    * All listeners registered via the `Impulse#subscribe` method execute whenever the Impulse's value updates.
@@ -176,27 +170,27 @@ export class Impulse<T> {
   ): void {
     const finalCompare = compare ?? eq
 
-    ScopeEmitter.schedule(() => {
+    ScopeEmitter._schedule(() => {
       const nextValue = isFunction(valueOrTransform)
-        ? valueOrTransform(this.value)
+        ? valueOrTransform(this._value)
         : valueOrTransform
 
-      if (finalCompare(this.value, nextValue)) {
+      if (finalCompare(this._value, nextValue)) {
         return null
       }
 
-      this.value = nextValue
+      this._value = nextValue
 
-      return this.emitters
+      return this._emitters
     })
   }
 
   @validate
-    .when("watch", WATCH_CALLING_IMPULSE_SUBSCRIBE)
-    .when("subscribe", SUBSCRIBE_CALLING_IMPULSE_SUBSCRIBE)
-    .when("useWatchImpulse", USE_WATCH_IMPULSE_CALLING_IMPULSE_SUBSCRIBE)
-    .when("useImpulseMemo", USE_IMPULSE_MEMO_CALLING_IMPULSE_SUBSCRIBE)
-    .prevent(noop)
+    ._when("watch", WATCH_CALLING_IMPULSE_SUBSCRIBE)
+    ._when("subscribe", SUBSCRIBE_CALLING_IMPULSE_SUBSCRIBE)
+    ._when("useWatchImpulse", USE_WATCH_IMPULSE_CALLING_IMPULSE_SUBSCRIBE)
+    ._when("useImpulseMemo", USE_IMPULSE_MEMO_CALLING_IMPULSE_SUBSCRIBE)
+    ._prevent(noop)
   /**
    * Subscribes to the value's updates caused by calling `Impulse#setValue`.
    *
@@ -211,8 +205,8 @@ export class Impulse<T> {
   public subscribe(listener: VoidFunction): VoidFunction {
     const emitter = new ScopeEmitter(false)
 
-    emitter.attachTo(this.emitters)
+    emitter._attachTo(this._emitters)
 
-    return emitter.onEmit(listener)
+    return emitter._onEmit(listener)
   }
 }

--- a/src/ScopeEmitter.ts
+++ b/src/ScopeEmitter.ts
@@ -8,90 +8,76 @@ import { noop } from "./utils"
  * @private
  */
 export class ScopeEmitter {
-  /*@__MANGLE_PROP__*/
-  private static queue: null | Array<null | ReadonlySet<ScopeEmitter>> = null
+  private static _queue: null | Array<null | ReadonlySet<ScopeEmitter>> = null
 
-  /*@__MANGLE_PROP__*/
-  public static schedule(
+  public static _schedule(
     execute: () => null | ReadonlySet<ScopeEmitter>,
   ): void {
-    if (ScopeEmitter.queue == null) {
-      ScopeEmitter.queue = []
+    if (ScopeEmitter._queue == null) {
+      ScopeEmitter._queue = []
 
-      ScopeEmitter.queue.push(execute())
+      ScopeEmitter._queue.push(execute())
 
       const uniq = new WeakSet<VoidFunction>()
 
-      ScopeEmitter.queue.forEach((emitters) => {
+      ScopeEmitter._queue.forEach((emitters) => {
         emitters?.forEach((emitter) => {
-          if (!uniq.has(emitter.emit)) {
-            uniq.add(emitter.emit)
-            emitter.increment()
+          if (!uniq.has(emitter._emit)) {
+            uniq.add(emitter._emit)
+            emitter._increment()
 
-            if (emitter.shouldDetachOnEmit) {
-              emitter.detachAll()
+            if (emitter._shouldDetachOnEmit) {
+              emitter._detachAll()
             }
 
-            emitter.emit()
+            emitter._emit()
           }
         })
       })
 
-      ScopeEmitter.queue = null
+      ScopeEmitter._queue = null
     } else {
-      ScopeEmitter.queue.push(execute())
+      ScopeEmitter._queue.push(execute())
     }
   }
 
   // TODO remove shouldDetachOnEmit when Impulse#subscribe is gone
-  /*@__MANGLE_PROP__*/
-  private readonly shouldDetachOnEmit: boolean = true
 
-  public constructor(shouldDetachOnEmit = true) {
-    this.shouldDetachOnEmit = shouldDetachOnEmit
+  public constructor(private readonly _shouldDetachOnEmit: boolean = true) {}
+
+  private readonly _cleanups: Array<VoidFunction> = []
+
+  private _version = 0
+
+  private _emit: VoidFunction = noop
+
+  private _increment(): void {
+    this._version = (this._version + 1) % 10e9
   }
 
-  /*@__MANGLE_PROP__*/
-  private readonly cleanups: Array<VoidFunction> = []
-
-  /*@__MANGLE_PROP__*/
-  private version = 0
-
-  /*@__MANGLE_PROP__*/
-  private emit: VoidFunction = noop
-
-  /*@__MANGLE_PROP__*/
-  private increment(): void {
-    this.version = (this.version + 1) % 10e9
+  public _detachAll(): void {
+    this._cleanups.forEach((cleanup) => cleanup())
+    this._cleanups.length = 0
   }
 
-  /*@__MANGLE_PROP__*/
-  public detachAll(): void {
-    this.cleanups.forEach((cleanup) => cleanup())
-    this.cleanups.length = 0
-  }
-
-  /*@__MANGLE_PROP__*/
-  public attachTo(emitters: Set<ScopeEmitter>): void {
+  public _attachTo(emitters: Set<ScopeEmitter>): void {
     if (!emitters.has(this)) {
       emitters.add(this)
-      this.cleanups.push(() => emitters.delete(this))
+      this._cleanups.push(() => emitters.delete(this))
     }
   }
 
-  /*@__MANGLE_PROP__*/
-  public onEmit = (emit: VoidFunction): VoidFunction => {
-    this.emit = emit
+  public _onEmit = (emit: VoidFunction): VoidFunction => {
+    this._emit = emit
 
     return () => {
-      this.increment()
-      this.detachAll()
-      this.emit = noop
+      this._increment()
+      this._detachAll()
+      this._emit = noop
     }
   }
 
-  /*@__MANGLE_PROP__*/
-  public getVersion = (): number => {
-    return this.version
+  public _getVersion = (): number => {
+    return this._version
   }
 }

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -8,7 +8,7 @@ import { ScopeEmitter } from "./ScopeEmitter"
  * @version 1.0.0
  */
 export function batch(execute: VoidFunction): void {
-  ScopeEmitter.schedule(() => {
+  ScopeEmitter._schedule(() => {
     execute()
 
     return null

--- a/src/subscribe.ts
+++ b/src/subscribe.ts
@@ -15,7 +15,7 @@ export function subscribe(listener: VoidFunction): VoidFunction {
       injectScope,
       {
         [EMITTER_KEY]: emitter,
-        version: emitter.getVersion(),
+        version: emitter._getVersion(),
       },
       listener,
     )
@@ -23,5 +23,5 @@ export function subscribe(listener: VoidFunction): VoidFunction {
 
   emit()
 
-  return emitter.onEmit(emit)
+  return emitter._onEmit(emit)
 }

--- a/src/useScope.ts
+++ b/src/useScope.ts
@@ -11,7 +11,7 @@ export function useScope<T = () => Scope>(
   const select = useCallback(
     (version: number) => {
       const getScope = (): Scope => {
-        emitter.detachAll()
+        emitter._detachAll()
 
         return {
           [EMITTER_KEY]: emitter,
@@ -25,9 +25,9 @@ export function useScope<T = () => Scope>(
   )
 
   return useSyncExternalStoreWithSelector(
-    emitter.onEmit,
-    emitter.getVersion,
-    emitter.getVersion,
+    emitter._onEmit,
+    emitter._getVersion,
+    emitter._getVersion,
     select,
     compare,
   )

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -35,20 +35,15 @@ type ValidateDecorator<TReturn = any> = (
 ) => void
 
 class Validate<TContext extends ExecutionContext> {
-  /*@__MANGLE_PROP__*/
-  private readonly spec: ReadonlyMap<ExecutionContext, string> = new Map()
+  public constructor(
+    private readonly _spec: ReadonlyMap<ExecutionContext, string>,
+  ) {}
 
-  public constructor(spec: ReadonlyMap<ExecutionContext, string>) {
-    this.spec = spec
+  private _getMessage(): null | undefined | string {
+    return currentExecutionContext && this._spec.get(currentExecutionContext)
   }
 
-  /*@__MANGLE_PROP__*/
-  private getMessage(): null | undefined | string {
-    return currentExecutionContext && this.spec.get(currentExecutionContext)
-  }
-
-  /*@__MANGLE_PROP__*/
-  private print(message: string): void {
+  private _print(message: string): void {
     if (
       typeof console !== "undefined" &&
       // eslint-disable-next-line no-console
@@ -62,16 +57,14 @@ class Validate<TContext extends ExecutionContext> {
     }
   }
 
-  /*@__MANGLE_PROP__*/
-  public when<TName extends TContext>(
+  public _when<TName extends TContext>(
     name: TName,
     message: string,
   ): Validate<Exclude<ExecutionContext, TName>> {
-    return new Validate(new Map(this.spec).set(name, message))
+    return new Validate(new Map(this._spec).set(name, message))
   }
 
-  /*@__MANGLE_PROP__*/
-  public alert(): ValidateDecorator {
+  public _alert(): ValidateDecorator {
     return (_, __, descriptor) => {
       if (process.env.NODE_ENV === "production") {
         /* c8 ignore next */
@@ -82,10 +75,10 @@ class Validate<TContext extends ExecutionContext> {
       const that = this
 
       descriptor.value = function (...args) {
-        const message = that.getMessage()
+        const message = that._getMessage()
 
         if (message) {
-          that.print(message)
+          that._print(message)
         }
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -94,10 +87,9 @@ class Validate<TContext extends ExecutionContext> {
     }
   }
 
-  public prevent(): ValidateDecorator
-  public prevent<TReturn>(returns: TReturn): ValidateDecorator<TReturn>
-  /*@__MANGLE_PROP__*/
-  public prevent<TReturn = void>(
+  public _prevent(): ValidateDecorator
+  public _prevent<TReturn>(returns: TReturn): ValidateDecorator<TReturn>
+  public _prevent<TReturn = void>(
     returns?: TReturn,
   ): ValidateDecorator<undefined | TReturn> {
     return (_, __, descriptor) => {
@@ -105,14 +97,14 @@ class Validate<TContext extends ExecutionContext> {
       const that = this
 
       descriptor.value = function (...args) {
-        const message = that.getMessage()
+        const message = that._getMessage()
 
         if (message == null) {
           return original.apply(this, args)
         }
 
         if (process.env.NODE_ENV !== "production") {
-          that.print(message)
+          that._print(message)
         }
 
         return returns

--- a/tests/Impulse.spec.ts
+++ b/tests/Impulse.spec.ts
@@ -1,5 +1,4 @@
 import { Impulse } from "../src"
-import { eq } from "../src/utils"
 
 import { Counter } from "./common"
 
@@ -30,16 +29,16 @@ describe("Impulse.of()", () => {
 
 describe("Impulse#compare", () => {
   describe("when creating an impulse with Impulse.of", () => {
-    it("assigns eq by default", () => {
+    it("assigns Object.is by default", () => {
       const impulse = Impulse.of({ count: 0 })
 
-      expect(impulse.compare).toBe(eq)
+      expect(impulse.compare).toBe(Object.is)
     })
 
-    it("assigns eq by `null`", () => {
+    it("assigns Object.is by `null`", () => {
       const impulse = Impulse.of({ count: 0 }, null)
 
-      expect(impulse.compare).toBe(eq)
+      expect(impulse.compare).toBe(Object.is)
     })
 
     it("assigns custom function", () => {
@@ -54,7 +53,7 @@ describe("Impulse#compare", () => {
       const impulse = Impulse.of({ count: 0 })
 
       expect(impulse.clone().compare).toBe(impulse.compare)
-      expect(impulse.clone().compare).toBe(eq)
+      expect(impulse.clone().compare).toBe(Object.is)
     })
 
     it("inherits custom the source impulse compare", () => {
@@ -64,10 +63,10 @@ describe("Impulse#compare", () => {
       expect(impulse.clone().compare).toBe(Counter.compare)
     })
 
-    it("assigns eq by `null`", () => {
+    it("assigns Object.is by `null`", () => {
       const impulse = Impulse.of({ count: 0 }, Counter.compare)
 
-      expect(impulse.clone(Counter.clone, null).compare).toBe(eq)
+      expect(impulse.clone(Counter.clone, null).compare).toBe(Object.is)
     })
 
     it("assigns custom function", () => {
@@ -88,7 +87,7 @@ describe("Impulse#compare", () => {
       expect(impulse.getValue()).toBe(initial)
     })
 
-    it("replaces with eq when `null`", () => {
+    it("replaces with Object.is when `null`", () => {
       const initial = { count: 0 }
       const impulse = Impulse.of(initial, Counter.compare)
 

--- a/tests/hooks-in-components/watch.spec.tsx
+++ b/tests/hooks-in-components/watch.spec.tsx
@@ -218,14 +218,14 @@ describe("watch()", () => {
     const result = screen.getByTestId("result")
 
     expect(result).toHaveTextContent("2")
-    expect(count).toHaveProperty("emitters.size", 1)
+    expect(count).toHaveEmittersSize(1)
 
     act(() => {
       count.setValue(3)
     })
 
     expect(result).toHaveTextContent("6")
-    expect(count).toHaveProperty("emitters.size", 1)
+    expect(count).toHaveEmittersSize(1)
   })
 
   it("should unsubscribe when impulse changes", () => {
@@ -241,14 +241,14 @@ describe("watch()", () => {
     const result = screen.getByTestId("result")
 
     expect(result).toHaveTextContent("1")
-    expect(count_1).toHaveProperty("emitters.size", 1)
-    expect(count_2).toHaveProperty("emitters.size", 0)
+    expect(count_1).toHaveEmittersSize(1)
+    expect(count_2).toHaveEmittersSize(0)
 
     rerender(<Component count={count_2} />)
 
     expect(result).toHaveTextContent("3")
-    expect(count_1).toHaveProperty("emitters.size", 0)
-    expect(count_2).toHaveProperty("emitters.size", 1)
+    expect(count_1).toHaveEmittersSize(0)
+    expect(count_2).toHaveEmittersSize(1)
   })
 
   it("should unsubscribe for conditionally rendered impulse when re-render is triggered by changing impulse value", () => {
@@ -269,15 +269,15 @@ describe("watch()", () => {
     const result = screen.getByTestId("result")
 
     expect(result).toHaveTextContent("none")
-    expect(count).toHaveProperty("emitters.size", 0)
-    expect(condition).toHaveProperty("emitters.size", 1)
+    expect(count).toHaveEmittersSize(0)
+    expect(condition).toHaveEmittersSize(1)
 
     act(() => {
       condition.setValue(true)
     })
     expect(result).toHaveTextContent("1")
-    expect(count).toHaveProperty("emitters.size", 1)
-    expect(condition).toHaveProperty("emitters.size", 1)
+    expect(count).toHaveEmittersSize(1)
+    expect(condition).toHaveEmittersSize(1)
 
     act(() => {
       count.setValue(2)
@@ -288,8 +288,8 @@ describe("watch()", () => {
       condition.setValue(false)
     })
     expect(result).toHaveTextContent("none")
-    expect(count).toHaveProperty("emitters.size", 0)
-    expect(condition).toHaveProperty("emitters.size", 1)
+    expect(count).toHaveEmittersSize(0)
+    expect(condition).toHaveEmittersSize(1)
   })
 
   it("should unsubscribe for conditionally rendered impulse when re-render is triggered by changing props", () => {
@@ -307,11 +307,11 @@ describe("watch()", () => {
     const result = screen.getByTestId("result")
 
     expect(result).toHaveTextContent("none")
-    expect(count).toHaveProperty("emitters.size", 0)
+    expect(count).toHaveEmittersSize(0)
 
     rerender(<Component count={count} condition={true} />)
     expect(result).toHaveTextContent("1")
-    expect(count).toHaveProperty("emitters.size", 1)
+    expect(count).toHaveEmittersSize(1)
 
     act(() => {
       count.setValue(2)
@@ -320,7 +320,7 @@ describe("watch()", () => {
 
     rerender(<Component count={count} condition={false} />)
     expect(result).toHaveTextContent("none")
-    expect(count).toHaveProperty("emitters.size", 0)
+    expect(count).toHaveEmittersSize(0)
   })
 
   it("should unsubscribe for conditionally rendered impulse when re-render is triggered by changing useState", () => {
@@ -348,11 +348,11 @@ describe("watch()", () => {
     const result = screen.getByTestId("result")
 
     expect(result).toHaveTextContent("none")
-    expect(count).toHaveProperty("emitters.size", 0)
+    expect(count).toHaveEmittersSize(0)
 
     fireEvent.click(result)
     expect(result).toHaveTextContent("1")
-    expect(count).toHaveProperty("emitters.size", 1)
+    expect(count).toHaveEmittersSize(1)
 
     act(() => {
       count.setValue(2)
@@ -361,7 +361,7 @@ describe("watch()", () => {
 
     fireEvent.click(result)
     expect(result).toHaveTextContent("none")
-    expect(count).toHaveProperty("emitters.size", 0)
+    expect(count).toHaveEmittersSize(0)
   })
 
   it("should not unsubscribe conditionally rendered impulse if it is used in another place", () => {
@@ -384,12 +384,12 @@ describe("watch()", () => {
 
     expect(x).toHaveTextContent("none")
     expect(y).toHaveTextContent("1")
-    expect(count).toHaveProperty("emitters.size", 1)
+    expect(count).toHaveEmittersSize(1)
 
     rerender(<Component count={count} condition={true} />)
     expect(x).toHaveTextContent("1")
     expect(y).toHaveTextContent("1")
-    expect(count).toHaveProperty("emitters.size", 1)
+    expect(count).toHaveEmittersSize(1)
 
     act(() => {
       count.setValue(2)
@@ -400,7 +400,7 @@ describe("watch()", () => {
     rerender(<Component count={count} condition={false} />)
     expect(x).toHaveTextContent("none")
     expect(y).toHaveTextContent("2")
-    expect(count).toHaveProperty("emitters.size", 1)
+    expect(count).toHaveEmittersSize(1)
   })
 
   it("should unsubscribe on unmount", () => {
@@ -415,11 +415,11 @@ describe("watch()", () => {
     const result = screen.getByTestId("result")
 
     expect(result).toHaveTextContent("1")
-    expect(count).toHaveProperty("emitters.size", 1)
+    expect(count).toHaveEmittersSize(1)
 
     unmount()
 
-    expect(count).toHaveProperty("emitters.size", 0)
+    expect(count).toHaveEmittersSize(0)
   })
 
   it("should not subscribe twice with useImpulseValue", () => {
@@ -438,14 +438,14 @@ describe("watch()", () => {
     const result = screen.getByTestId("result")
 
     expect(result).toHaveTextContent("1")
-    expect(count).toHaveProperty("emitters.size", 1)
+    expect(count).toHaveEmittersSize(1)
 
     act(() => {
       count.setValue(2)
     })
 
     expect(result).toHaveTextContent("2")
-    expect(count).toHaveProperty("emitters.size", 1)
+    expect(count).toHaveEmittersSize(1)
   })
 })
 

--- a/tests/illegal-usage.spec.tsx
+++ b/tests/illegal-usage.spec.tsx
@@ -345,9 +345,12 @@ describe("calling Impulse#subscribe()", () => {
         initialProps: { impulse },
       })
 
-      expect(impulse$subscribe).toHaveReturnedWith(
-        expect.objectContaining({ name: "noop" }),
-      )
+      expect(impulse).toHaveEmittersSize(1)
+      expect(impulse$subscribe.mock.results).toHaveLength(1)
+      expect(impulse$subscribe.mock.results[0]?.type).toBe("return")
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      impulse$subscribe.mock.results[0]?.value()
+      expect(impulse).toHaveEmittersSize(1)
     })
 
     it("does not call the listener on Impulse's change", () => {
@@ -475,9 +478,12 @@ describe("calling Impulse#subscribe()", () => {
       const impulse$subscribe = vi.spyOn(impulse, "subscribe")
       render(<Component impulse={impulse} />)
 
-      expect(impulse$subscribe).toHaveReturnedWith(
-        expect.objectContaining({ name: "noop" }),
-      )
+      expect(impulse).toHaveEmittersSize(1)
+      expect(impulse$subscribe.mock.results).toHaveLength(1)
+      expect(impulse$subscribe.mock.results[0]?.type).toBe("return")
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      impulse$subscribe.mock.results[0]?.value()
+      expect(impulse).toHaveEmittersSize(1)
     })
 
     it("does not call the listener on Impulse's change", () => {
@@ -521,12 +527,16 @@ describe("calling Impulse#subscribe()", () => {
       const impulse$subscribe = vi.spyOn(impulse, "subscribe")
 
       subscribe(() => {
+        impulse.getValue()
         impulse.subscribe(listener)
       })
 
-      expect(impulse$subscribe).toHaveReturnedWith(
-        expect.objectContaining({ name: "noop" }),
-      )
+      expect(impulse).toHaveEmittersSize(1)
+      expect(impulse$subscribe.mock.results).toHaveLength(1)
+      expect(impulse$subscribe.mock.results[0]?.type).toBe("return")
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      impulse$subscribe.mock.results[0]?.value()
+      expect(impulse).toHaveEmittersSize(1)
     })
 
     it("does not call the listener on Impulse's change", () => {

--- a/tests/illegal-usage.spec.tsx
+++ b/tests/illegal-usage.spec.tsx
@@ -10,22 +10,6 @@ import {
   useWatchImpulse,
   watch,
 } from "../src"
-import { noop, usePermanent } from "../src/utils"
-import {
-  WATCH_CALLING_IMPULSE_SET_VALUE,
-  WATCH_CALLING_IMPULSE_SUBSCRIBE,
-  SUBSCRIBE_CALLING_IMPULSE_OF,
-  SUBSCRIBE_CALLING_IMPULSE_CLONE,
-  SUBSCRIBE_CALLING_IMPULSE_SUBSCRIBE,
-  USE_WATCH_IMPULSE_CALLING_IMPULSE_OF,
-  USE_WATCH_IMPULSE_CALLING_IMPULSE_CLONE,
-  USE_WATCH_IMPULSE_CALLING_IMPULSE_SET_VALUE,
-  USE_WATCH_IMPULSE_CALLING_IMPULSE_SUBSCRIBE,
-  USE_IMPULSE_MEMO_CALLING_IMPULSE_OF,
-  USE_IMPULSE_MEMO_CALLING_IMPULSE_CLONE,
-  USE_IMPULSE_MEMO_CALLING_IMPULSE_SET_VALUE,
-  USE_IMPULSE_MEMO_CALLING_IMPULSE_SUBSCRIBE,
-} from "../src/messages"
 
 import { WithImpulse, WithListener } from "./common"
 
@@ -45,14 +29,14 @@ describe("calling Impulse.of()", () => {
   describe.each([
     [
       "useImpulseMemo",
-      USE_IMPULSE_MEMO_CALLING_IMPULSE_OF,
+      "You should not call Impulse.of inside of the useImpulseMemo factory. The useImpulseMemo hook is for read-only operations but Impulse.of creates a new Impulse.",
       () => {
         return useImpulseMemo(() => Impulse.of(1).getValue(), [])
       },
     ],
     [
       "useWatchImpulse",
-      USE_WATCH_IMPULSE_CALLING_IMPULSE_OF,
+      "You should not call Impulse.of inside of the useWatchImpulse watcher. The useWatchImpulse hook is for read-only operations but Impulse.of creates a new Impulse.",
       () => {
         return useWatchImpulse(() => Impulse.of(1).getValue())
       },
@@ -76,7 +60,9 @@ describe("calling Impulse.of()", () => {
       Impulse.of(1)
     })
 
-    expect(console$error).toHaveBeenLastCalledWith(SUBSCRIBE_CALLING_IMPULSE_OF)
+    expect(console$error).toHaveBeenLastCalledWith(
+      "You should not call Impulse.of inside of the subscribe listener. The listener is for read-only operations but Impulse.of creates a new Impulse.",
+    )
   })
 
   it.each([
@@ -99,7 +85,7 @@ describe("calling Impulse.of()", () => {
 
   it("fine when called inside watch()", () => {
     const Component = watch(() => {
-      const state = usePermanent(() => Impulse.of(20))
+      const [state] = React.useState(() => Impulse.of(20))
 
       return <div data-testid="count">{state.getValue()}</div>
     })
@@ -115,14 +101,14 @@ describe("calling Impulse#clone()", () => {
   describe.each([
     [
       "useImpulseMemo",
-      USE_IMPULSE_MEMO_CALLING_IMPULSE_CLONE,
+      "You should not call Impulse#clone inside of the useImpulseMemo factory. The useImpulseMemo hook is for read-only operations but Impulse#clone clones an existing Impulse.",
       ({ impulse }: WithImpulse<number>) => {
         return useImpulseMemo(() => impulse.clone().getValue(), [impulse])
       },
     ],
     [
       "useWatchImpulse",
-      USE_WATCH_IMPULSE_CALLING_IMPULSE_CLONE,
+      "You should not call Impulse#clone inside of the useWatchImpulse watcher. The useWatchImpulse hook is for read-only operations but Impulse#clone clones an existing Impulse.",
       ({ impulse }: WithImpulse<number>) => {
         return useWatchImpulse(() => impulse.clone().getValue())
       },
@@ -155,7 +141,7 @@ describe("calling Impulse#clone()", () => {
     })
 
     expect(console$error).toHaveBeenLastCalledWith(
-      SUBSCRIBE_CALLING_IMPULSE_CLONE,
+      "You should not call Impulse#clone inside of the subscribe listener. The listener is for read-only operations but Impulse#clone clones an existing Impulse.",
     )
   })
 
@@ -190,7 +176,7 @@ describe("calling Impulse#clone()", () => {
     const Component = watch<{
       impulse: Impulse<number>
     }>(({ impulse }) => {
-      const state = usePermanent(() => impulse.clone())
+      const [state] = React.useState(() => impulse.clone())
 
       return <div data-testid="count">{state.getValue()}</div>
     })
@@ -206,7 +192,7 @@ describe("calling Impulse#setValue()", () => {
   describe.each([
     [
       "useImpulseMemo",
-      USE_IMPULSE_MEMO_CALLING_IMPULSE_SET_VALUE,
+      "You should not call Impulse#setValue inside of the useImpulseMemo factory. The useImpulseMemo hook is for read-only operations but Impulse#setValue changes an existing Impulse.",
       ({ impulse }: WithImpulse<number>) => {
         return useImpulseMemo(() => {
           impulse.setValue(3)
@@ -217,7 +203,7 @@ describe("calling Impulse#setValue()", () => {
     ],
     [
       "useWatchImpulse",
-      USE_WATCH_IMPULSE_CALLING_IMPULSE_SET_VALUE,
+      "You should not call Impulse#setValue inside of the useWatchImpulse watcher. The useWatchImpulse hook is for read-only operations but Impulse#setValue changes an existing Impulse.",
       ({ impulse }: WithImpulse<number>) => {
         return useWatchImpulse(() => {
           impulse.setValue(3)
@@ -294,7 +280,9 @@ describe("calling Impulse#setValue()", () => {
 
     render(<Component impulse={Impulse.of(20)} />)
 
-    expect(console$error).toHaveBeenCalledWith(WATCH_CALLING_IMPULSE_SET_VALUE)
+    expect(console$error).toHaveBeenCalledWith(
+      "You should not call Impulse#setValue during rendering of watch(Component).",
+    )
     expect(screen.getByTestId("count")).toHaveTextContent("20")
   })
 })
@@ -303,7 +291,7 @@ describe("calling Impulse#subscribe()", () => {
   describe.each([
     [
       "useImpulseMemo",
-      USE_IMPULSE_MEMO_CALLING_IMPULSE_SUBSCRIBE,
+      "You may not call Impulse#subscribe inside of the useImpulseMemo factory. The useImpulseMemo hook is for read-only operations but Impulse#subscribe subscribes to an Impulse.",
       ({
         impulse,
         listener = vi.fn(),
@@ -317,7 +305,7 @@ describe("calling Impulse#subscribe()", () => {
     ],
     [
       "useWatchImpulse",
-      USE_WATCH_IMPULSE_CALLING_IMPULSE_SUBSCRIBE,
+      "You may not call Impulse#subscribe inside of the useWatchImpulse watcher. The useWatchImpulse hook is for read-only operations but Impulse#subscribe subscribes to an Impulse.",
       ({
         impulse,
         listener = vi.fn(),
@@ -357,7 +345,9 @@ describe("calling Impulse#subscribe()", () => {
         initialProps: { impulse },
       })
 
-      expect(impulse$subscribe).toHaveReturnedWith(noop)
+      expect(impulse$subscribe).toHaveReturnedWith(
+        expect.objectContaining({ name: "noop" }),
+      )
     })
 
     it("does not call the listener on Impulse's change", () => {
@@ -470,7 +460,7 @@ describe("calling Impulse#subscribe()", () => {
       render(<Component impulse={Impulse.of(20)} />)
 
       expect(console$error).toHaveBeenCalledWith(
-        WATCH_CALLING_IMPULSE_SUBSCRIBE,
+        "You may not call Impulse#subscribe during rendering of watch(Component).",
       )
     })
 
@@ -485,7 +475,9 @@ describe("calling Impulse#subscribe()", () => {
       const impulse$subscribe = vi.spyOn(impulse, "subscribe")
       render(<Component impulse={impulse} />)
 
-      expect(impulse$subscribe).toHaveReturnedWith(noop)
+      expect(impulse$subscribe).toHaveReturnedWith(
+        expect.objectContaining({ name: "noop" }),
+      )
     })
 
     it("does not call the listener on Impulse's change", () => {
@@ -520,7 +512,7 @@ describe("calling Impulse#subscribe()", () => {
       })
 
       expect(console$error).toHaveBeenCalledWith(
-        SUBSCRIBE_CALLING_IMPULSE_SUBSCRIBE,
+        "You may not call Impulse#subscribe inside of the subscribe listener. The listener is for read-only operations but Impulse#subscribe subscribes to an Impulse.",
       )
     })
 
@@ -532,7 +524,9 @@ describe("calling Impulse#subscribe()", () => {
         impulse.subscribe(listener)
       })
 
-      expect(impulse$subscribe).toHaveReturnedWith(noop)
+      expect(impulse$subscribe).toHaveReturnedWith(
+        expect.objectContaining({ name: "noop" }),
+      )
     })
 
     it("does not call the listener on Impulse's change", () => {

--- a/tests/subscribe.spec.tsx
+++ b/tests/subscribe.spec.tsx
@@ -1,5 +1,4 @@
-import { Impulse, batch } from "../src"
-import { subscribe } from "../src/subscribe"
+import { Impulse, batch, subscribe } from "../src"
 
 import { Counter } from "./common"
 

--- a/tests/subscribe.spec.tsx
+++ b/tests/subscribe.spec.tsx
@@ -1,4 +1,5 @@
-import { Impulse, batch, subscribe } from "../src"
+import { Impulse, batch } from "../src"
+import { subscribe } from "../src/subscribe"
 
 import { Counter } from "./common"
 

--- a/tests/subscribe.spec.tsx
+++ b/tests/subscribe.spec.tsx
@@ -14,7 +14,7 @@ describe("single Impulse", () => {
 
     expect(spy).toHaveBeenCalledOnce()
     expect(spy).toHaveBeenLastCalledWith(1)
-    expect(impulse).toHaveProperty("emitters.size", 1)
+    expect(impulse).toHaveEmittersSize(1)
   })
 
   it("executes listener on update", () => {
@@ -29,7 +29,7 @@ describe("single Impulse", () => {
     impulse.setValue(2)
     expect(spy).toHaveBeenCalledOnce()
     expect(spy).toHaveBeenLastCalledWith(2)
-    expect(impulse).toHaveProperty("emitters.size", 1)
+    expect(impulse).toHaveEmittersSize(1)
   })
 
   it("doesn't execute listener after unsubscribe", () => {
@@ -45,7 +45,7 @@ describe("single Impulse", () => {
     spy.mockReset()
     impulse.setValue(2)
     expect(spy).not.toHaveBeenCalled()
-    expect(impulse).toHaveProperty("emitters.size", 0)
+    expect(impulse).toHaveEmittersSize(0)
   })
 
   it("ignores second unsubscribe", () => {
@@ -62,7 +62,7 @@ describe("single Impulse", () => {
     spy.mockReset()
     impulse.setValue(2)
     expect(spy).not.toHaveBeenCalled()
-    expect(impulse).toHaveProperty("emitters.size", 0)
+    expect(impulse).toHaveEmittersSize(0)
   })
 
   it("executes listener on every Impulse update", () => {
@@ -78,7 +78,7 @@ describe("single Impulse", () => {
     impulse.setValue(3)
     expect(spy).toHaveBeenCalledTimes(2)
     expect(spy).toHaveBeenLastCalledWith(3)
-    expect(impulse).toHaveProperty("emitters.size", 1)
+    expect(impulse).toHaveEmittersSize(1)
   })
 
   it("executes listener ones for batched Impulse updates", () => {
@@ -96,7 +96,7 @@ describe("single Impulse", () => {
     })
     expect(spy).toHaveBeenCalledOnce()
     expect(spy).toHaveBeenLastCalledWith(3)
-    expect(impulse).toHaveProperty("emitters.size", 1)
+    expect(impulse).toHaveEmittersSize(1)
   })
 
   it("doesn't execute listener when Impulse value does not change", () => {
@@ -110,7 +110,7 @@ describe("single Impulse", () => {
     spy.mockReset()
     impulse.setValue(1)
     expect(spy).not.toHaveBeenCalled()
-    expect(impulse).toHaveProperty("emitters.size", 1)
+    expect(impulse).toHaveEmittersSize(1)
   })
 
   it("doesn't execute listener when Impulse value comparably the same", () => {
@@ -129,7 +129,7 @@ describe("single Impulse", () => {
     impulse.setValue({ count: 2 })
     expect(spy).toHaveBeenCalledOnce()
     expect(spy).toHaveBeenLastCalledWith({ count: 2 })
-    expect(impulse).toHaveProperty("emitters.size", 1)
+    expect(impulse).toHaveEmittersSize(1)
   })
 })
 
@@ -145,8 +145,8 @@ describe("multiple Impulses", () => {
 
     expect(spy).toHaveBeenCalledOnce()
     expect(spy).toHaveBeenLastCalledWith(3)
-    expect(impulse_1).toHaveProperty("emitters.size", 1)
-    expect(impulse_2).toHaveProperty("emitters.size", 1)
+    expect(impulse_1).toHaveEmittersSize(1)
+    expect(impulse_2).toHaveEmittersSize(1)
   })
 
   it("executes listener on update", () => {
@@ -167,8 +167,8 @@ describe("multiple Impulses", () => {
     impulse_2.setValue(4)
     expect(spy).toHaveBeenCalledOnce()
     expect(spy).toHaveBeenLastCalledWith(7)
-    expect(impulse_1).toHaveProperty("emitters.size", 1)
-    expect(impulse_2).toHaveProperty("emitters.size", 1)
+    expect(impulse_1).toHaveEmittersSize(1)
+    expect(impulse_2).toHaveEmittersSize(1)
   })
 
   it("doesn't execute listener after unsubscribe", () => {
@@ -181,8 +181,8 @@ describe("multiple Impulses", () => {
     })
 
     unsubscribe()
-    expect(impulse_1).toHaveProperty("emitters.size", 0)
-    expect(impulse_2).toHaveProperty("emitters.size", 0)
+    expect(impulse_1).toHaveEmittersSize(0)
+    expect(impulse_2).toHaveEmittersSize(0)
 
     spy.mockReset()
     impulse_1.setValue(4)
@@ -200,34 +200,34 @@ describe("multiple Impulses", () => {
         spy(impulse_1.getValue() + impulse_2.getValue())
       }
     })
-    expect(impulse_1).toHaveProperty("emitters.size", 1)
-    expect(impulse_2).toHaveProperty("emitters.size", 0)
+    expect(impulse_1).toHaveEmittersSize(1)
+    expect(impulse_2).toHaveEmittersSize(0)
 
     spy.mockReset()
     impulse_2.setValue(3)
     expect(spy).not.toHaveBeenCalled()
-    expect(impulse_1).toHaveProperty("emitters.size", 1)
-    expect(impulse_2).toHaveProperty("emitters.size", 0)
+    expect(impulse_1).toHaveEmittersSize(1)
+    expect(impulse_2).toHaveEmittersSize(0)
 
     spy.mockReset()
     impulse_1.setValue(2)
     expect(spy).toHaveBeenCalledOnce()
     expect(spy).toHaveBeenLastCalledWith(5)
-    expect(impulse_1).toHaveProperty("emitters.size", 1)
-    expect(impulse_2).toHaveProperty("emitters.size", 1)
+    expect(impulse_1).toHaveEmittersSize(1)
+    expect(impulse_2).toHaveEmittersSize(1)
 
     spy.mockReset()
     impulse_2.setValue(4)
     expect(spy).toHaveBeenCalledOnce()
     expect(spy).toHaveBeenLastCalledWith(6)
-    expect(impulse_1).toHaveProperty("emitters.size", 1)
-    expect(impulse_2).toHaveProperty("emitters.size", 1)
+    expect(impulse_1).toHaveEmittersSize(1)
+    expect(impulse_2).toHaveEmittersSize(1)
 
     spy.mockReset()
     impulse_1.setValue(1)
     expect(spy).not.toHaveBeenCalled()
-    expect(impulse_1).toHaveProperty("emitters.size", 1)
-    expect(impulse_2).toHaveProperty("emitters.size", 0)
+    expect(impulse_1).toHaveEmittersSize(1)
+    expect(impulse_2).toHaveEmittersSize(0)
   })
 })
 
@@ -249,9 +249,9 @@ describe("nested Impulses", () => {
       )
     })
 
-    expect(impulse_1).toHaveProperty("emitters.size", 1)
-    expect(impulse_2).toHaveProperty("emitters.size", 1)
-    expect(impulse_3).toHaveProperty("emitters.size", 1)
+    expect(impulse_1).toHaveEmittersSize(1)
+    expect(impulse_2).toHaveEmittersSize(1)
+    expect(impulse_3).toHaveEmittersSize(1)
 
     expect(spy).toHaveBeenCalledOnce()
     expect(spy).toHaveBeenLastCalledWith(3)

--- a/tests/useImpulse.spec.ts
+++ b/tests/useImpulse.spec.ts
@@ -1,7 +1,6 @@
 import { act, renderHook } from "@testing-library/react"
 
 import { Compare, useImpulse } from "../src"
-import * as utils from "../src/utils"
 
 describe("without initial value", () => {
   it("should create an impulse with undefined initial value", () => {
@@ -127,32 +126,30 @@ describe("with lazy initial value", () => {
 })
 
 describe("with compare function", () => {
-  it("applies eq by default", () => {
-    const spy_eq = vi.spyOn(utils, "eq")
+  it("applies Object.is by default", () => {
     const { result } = renderHook(() => useImpulse(0))
 
-    expect(spy_eq).not.toHaveBeenCalled()
+    expect(Object.is).not.toHaveBeenCalled()
 
     act(() => {
       result.current.setValue((x) => x + 1)
     })
 
-    expect(spy_eq).toHaveBeenCalledOnce()
-    expect(spy_eq).toHaveBeenLastCalledWith(0, 1)
+    expect(Object.is).toHaveBeenCalledOnce()
+    expect(Object.is).toHaveBeenLastCalledWith(0, 1)
   })
 
-  it("applies eq when passing null as compare", () => {
-    const spy_eq = vi.spyOn(utils, "eq")
+  it("applies Object.is when passing null as compare", () => {
     const { result } = renderHook(() => useImpulse(0, null))
 
-    expect(spy_eq).not.toHaveBeenCalled()
+    expect(Object.is).not.toHaveBeenCalled()
 
     act(() => {
       result.current.setValue((x) => x + 1)
     })
 
-    expect(spy_eq).toHaveBeenCalledOnce()
-    expect(spy_eq).toHaveBeenLastCalledWith(0, 1)
+    expect(Object.is).toHaveBeenCalledOnce()
+    expect(Object.is).toHaveBeenLastCalledWith(0, 1)
   })
 
   it("does not call the function on init", () => {
@@ -177,7 +174,6 @@ describe("with compare function", () => {
   it("updates compare function on re-render", () => {
     const compare_1 = vi.fn().mockImplementation(Object.is)
     const compare_2 = vi.fn().mockImplementation(Object.is)
-    const spy_eq = vi.spyOn(utils, "eq")
 
     const { result, rerender } = renderHook(
       (compare: null | Compare<number>) => useImpulse<number>(0, compare),
@@ -207,7 +203,7 @@ describe("with compare function", () => {
       result.current.setValue((x) => x + 1)
     })
     expect(compare_2).not.toHaveBeenCalled()
-    expect(spy_eq).toHaveBeenCalledOnce()
-    expect(spy_eq).toHaveBeenLastCalledWith(2, 3)
+    expect(Object.is).toHaveBeenCalledOnce()
+    expect(Object.is).toHaveBeenLastCalledWith(2, 3)
   })
 })

--- a/tests/useImpulseEffect.spec.tsx
+++ b/tests/useImpulseEffect.spec.tsx
@@ -134,7 +134,7 @@ describe.each([
 
         expect(onEffect).toHaveBeenCalledOnce()
         expect(onEffect).toHaveBeenLastCalledWith(6)
-        expect(value).toHaveProperty("emitters.size", 1)
+        expect(value).toHaveEmittersSize(1)
         expect(onRender).toHaveBeenCalledOnce()
       })
 
@@ -185,8 +185,8 @@ describe.each([
             />
           </React.Profiler>,
         )
-        expect(value_1).toHaveProperty("emitters.size", 1)
-        expect(value_2).toHaveProperty("emitters.size", 0)
+        expect(value_1).toHaveEmittersSize(1)
+        expect(value_2).toHaveEmittersSize(0)
 
         vi.clearAllMocks()
 
@@ -199,8 +199,8 @@ describe.each([
             />
           </React.Profiler>,
         )
-        expect(value_1).toHaveProperty("emitters.size", 0)
-        expect(value_2).toHaveProperty("emitters.size", 1)
+        expect(value_1).toHaveEmittersSize(0)
+        expect(value_2).toHaveEmittersSize(1)
 
         expect(onEffect).toHaveBeenCalledOnce()
         expect(onRender).toHaveBeenCalledOnce()
@@ -220,8 +220,8 @@ describe.each([
         expect(onEffect).toHaveBeenCalledOnce()
         expect(onEffect).toHaveBeenLastCalledWith(10)
         expect(onRender).toHaveBeenCalledOnce()
-        expect(value_1).toHaveProperty("emitters.size", 0)
-        expect(value_2).toHaveProperty("emitters.size", 1)
+        expect(value_1).toHaveEmittersSize(0)
+        expect(value_2).toHaveEmittersSize(1)
       })
 
       it("should call useEffect factory when non Impulse dep changes", () => {
@@ -245,7 +245,7 @@ describe.each([
         expect(onEffect).toHaveBeenCalledOnce()
         expect(onEffect).toHaveBeenLastCalledWith(9)
         expect(onRender).toHaveBeenCalledOnce()
-        expect(value).toHaveProperty("emitters.size", 1)
+        expect(value).toHaveEmittersSize(1)
         vi.clearAllMocks()
 
         act(() => {
@@ -254,7 +254,7 @@ describe.each([
         expect(onEffect).toHaveBeenCalledOnce()
         expect(onEffect).toHaveBeenLastCalledWith(12)
         expect(onRender).toHaveBeenCalledOnce()
-        expect(value).toHaveProperty("emitters.size", 1)
+        expect(value).toHaveEmittersSize(1)
       })
     })
 
@@ -289,8 +289,8 @@ describe.each([
 
         expect(onEffect).toHaveBeenCalledOnce()
         expect(onEffect).toHaveBeenLastCalledWith(10)
-        expect(first).toHaveProperty("emitters.size", 1)
-        expect(second).toHaveProperty("emitters.size", 1)
+        expect(first).toHaveEmittersSize(1)
+        expect(second).toHaveEmittersSize(1)
         vi.clearAllMocks()
 
         act(() => {
@@ -307,8 +307,8 @@ describe.each([
 
         expect(onEffect).toHaveBeenCalledOnce()
         expect(onEffect).toHaveBeenLastCalledWith(18)
-        expect(first).toHaveProperty("emitters.size", 1)
-        expect(second).toHaveProperty("emitters.size", 1)
+        expect(first).toHaveEmittersSize(1)
+        expect(second).toHaveEmittersSize(1)
       })
     })
 
@@ -349,10 +349,10 @@ describe.each([
 
         expect(onEffect).toHaveBeenCalledOnce()
         expect(onEffect).toHaveBeenLastCalledWith(10)
-        expect(list).toHaveProperty("emitters.size", 1)
-        expect(_0).toHaveProperty("emitters.size", 1)
-        expect(_1).toHaveProperty("emitters.size", 1)
-        expect(_2).toHaveProperty("emitters.size", 0)
+        expect(list).toHaveEmittersSize(1)
+        expect(_0).toHaveEmittersSize(1)
+        expect(_1).toHaveEmittersSize(1)
+        expect(_2).toHaveEmittersSize(0)
         vi.clearAllMocks()
 
         act(() => {
@@ -377,7 +377,7 @@ describe.each([
 
         expect(onEffect).toHaveBeenCalledOnce()
         expect(onEffect).toHaveBeenLastCalledWith(26)
-        expect(_2).toHaveProperty("emitters.size", 1)
+        expect(_2).toHaveEmittersSize(1)
         vi.clearAllMocks()
 
         act(() => {
@@ -386,10 +386,10 @@ describe.each([
 
         expect(onEffect).toHaveBeenCalledOnce()
         expect(onEffect).toHaveBeenLastCalledWith(18)
-        expect(list).toHaveProperty("emitters.size", 1)
-        expect(_0).toHaveProperty("emitters.size", 0)
-        expect(_1).toHaveProperty("emitters.size", 1)
-        expect(_2).toHaveProperty("emitters.size", 1)
+        expect(list).toHaveEmittersSize(1)
+        expect(_0).toHaveEmittersSize(0)
+        expect(_1).toHaveEmittersSize(1)
+        expect(_2).toHaveEmittersSize(1)
       })
     })
 
@@ -431,7 +431,7 @@ describe.each([
 
         expect(onEffect).toHaveBeenCalledOnce()
         expect(onEffect).toHaveBeenLastCalledWith(6)
-        expect(value).toHaveProperty("emitters.size", 1)
+        expect(value).toHaveEmittersSize(1)
       })
 
       it("calls effect when inner useState changes", () => {
@@ -448,7 +448,7 @@ describe.each([
 
         expect(onEffect).toHaveBeenCalledOnce()
         expect(onEffect).toHaveBeenLastCalledWith(9)
-        expect(value).toHaveProperty("emitters.size", 1)
+        expect(value).toHaveEmittersSize(1)
       })
 
       it("calls effect when Impulse inside an effect changes", () => {
@@ -467,7 +467,7 @@ describe.each([
 
         expect(onEffect).toHaveBeenCalledOnce()
         expect(onEffect).toHaveBeenLastCalledWith(8)
-        expect(value).toHaveProperty("emitters.size", 1)
+        expect(value).toHaveEmittersSize(1)
       })
     })
   })

--- a/tests/useImpulseMemo.spec.tsx
+++ b/tests/useImpulseMemo.spec.tsx
@@ -68,7 +68,7 @@ describe.each([
       expect(node).toHaveTextContent("2")
       expect(onMemo).toHaveBeenCalledOnce()
       expect(onRender).toHaveBeenCalledOnce()
-      expect(value).toHaveProperty("emitters.size", 1)
+      expect(value).toHaveEmittersSize(1)
       vi.clearAllMocks()
 
       act(() => {
@@ -78,7 +78,7 @@ describe.each([
       expect(node).toHaveTextContent("4")
       expect(onMemo).toHaveBeenCalledOnce()
       expect(onRender).toHaveBeenCalledOnce()
-      expect(value).toHaveProperty("emitters.size", 1)
+      expect(value).toHaveEmittersSize(1)
     })
 
     it("does not call useMemo factory when deps not changed", () => {
@@ -113,7 +113,7 @@ describe.each([
 
       expect(onMemo).toHaveBeenCalledOnce()
       expect(onMemo).toHaveBeenLastCalledWith(6)
-      expect(value).toHaveProperty("emitters.size", 1)
+      expect(value).toHaveEmittersSize(1)
       expect(onRender).toHaveBeenCalledOnce()
     })
 
@@ -153,16 +153,16 @@ describe.each([
         </React.Profiler>,
       )
 
-      expect(value_1).toHaveProperty("emitters.size", 1)
-      expect(value_2).toHaveProperty("emitters.size", 0)
+      expect(value_1).toHaveEmittersSize(1)
+      expect(value_2).toHaveEmittersSize(0)
 
       rerender(
         <React.Profiler id="test" onRender={onRender}>
           <Component useMemo={useImpulseMemo} onMemo={onMemo} value={value_2} />
         </React.Profiler>,
       )
-      expect(value_1).toHaveProperty("emitters.size", 0)
-      expect(value_2).toHaveProperty("emitters.size", 1)
+      expect(value_1).toHaveEmittersSize(0)
+      expect(value_2).toHaveEmittersSize(1)
 
       vi.clearAllMocks()
 
@@ -181,8 +181,8 @@ describe.each([
       expect(onMemo).toHaveBeenLastCalledWith(10)
       expect(onRender).toHaveBeenCalledOnce()
 
-      expect(value_1).toHaveProperty("emitters.size", 0)
-      expect(value_2).toHaveProperty("emitters.size", 1)
+      expect(value_1).toHaveEmittersSize(0)
+      expect(value_2).toHaveEmittersSize(1)
     })
 
     it("should call useMemo factory when none-Impulse dep changes", () => {
@@ -202,7 +202,7 @@ describe.each([
       expect(onMemo).toHaveBeenCalledOnce()
       expect(onMemo).toHaveBeenLastCalledWith(9)
       expect(onRender).toHaveBeenCalledOnce()
-      expect(value).toHaveProperty("emitters.size", 1)
+      expect(value).toHaveEmittersSize(1)
       vi.clearAllMocks()
 
       act(() => {
@@ -211,7 +211,7 @@ describe.each([
       expect(onMemo).toHaveBeenCalledOnce()
       expect(onMemo).toHaveBeenLastCalledWith(12)
       expect(onRender).toHaveBeenCalledOnce()
-      expect(value).toHaveProperty("emitters.size", 1)
+      expect(value).toHaveEmittersSize(1)
     })
   })
 
@@ -245,8 +245,8 @@ describe.each([
 
       const node = screen.getByTestId("value")
 
-      expect(first).toHaveProperty("emitters.size", 1)
-      expect(second).toHaveProperty("emitters.size", 1)
+      expect(first).toHaveEmittersSize(1)
+      expect(second).toHaveEmittersSize(1)
       expect(node).toHaveTextContent("10")
 
       act(() => {
@@ -259,8 +259,8 @@ describe.each([
       })
       expect(node).toHaveTextContent("18")
 
-      expect(first).toHaveProperty("emitters.size", 1)
-      expect(second).toHaveProperty("emitters.size", 1)
+      expect(first).toHaveEmittersSize(1)
+      expect(second).toHaveEmittersSize(1)
     })
   })
 
@@ -299,10 +299,10 @@ describe.each([
 
       render(<Component list={list} />)
 
-      expect(list).toHaveProperty("emitters.size", 1)
-      expect(_0).toHaveProperty("emitters.size", 1)
-      expect(_1).toHaveProperty("emitters.size", 1)
-      expect(_2).toHaveProperty("emitters.size", 0)
+      expect(list).toHaveEmittersSize(1)
+      expect(_0).toHaveEmittersSize(1)
+      expect(_1).toHaveEmittersSize(1)
+      expect(_2).toHaveEmittersSize(0)
 
       const node = screen.getByTestId("value")
 
@@ -323,17 +323,17 @@ describe.each([
       })
       expect(node).toHaveTextContent("26")
 
-      expect(_2).toHaveProperty("emitters.size", 1)
+      expect(_2).toHaveEmittersSize(1)
 
       act(() => {
         list.setValue((items) => items.slice(1))
       })
       expect(node).toHaveTextContent("18")
 
-      expect(list).toHaveProperty("emitters.size", 1)
-      expect(_0).toHaveProperty("emitters.size", 0)
-      expect(_1).toHaveProperty("emitters.size", 1)
-      expect(_2).toHaveProperty("emitters.size", 1)
+      expect(list).toHaveEmittersSize(1)
+      expect(_0).toHaveEmittersSize(0)
+      expect(_1).toHaveEmittersSize(1)
+      expect(_2).toHaveEmittersSize(1)
     })
   })
 })

--- a/tests/useWatchImpulse/watcher-comparator.spec.ts
+++ b/tests/useWatchImpulse/watcher-comparator.spec.ts
@@ -1,9 +1,8 @@
 import { useCallback } from "react"
 import { act, renderHook } from "@testing-library/react"
 
-import { Impulse, useWatchImpulse } from "../../src"
+import { type Compare, Impulse, useWatchImpulse } from "../../src"
 import { Counter, WithCompare, WithImpulse } from "../common"
-import { Compare, eq } from "../../src/utils"
 
 describe.each([
   [
@@ -54,7 +53,7 @@ describe.each([
 
       rerender({
         impulse,
-        compare: eq,
+        compare: Object.is,
       })
       expect(result.current).toBe(initial)
 

--- a/tests/useWatchImpulse/watching-conditional-impulse.spec.ts
+++ b/tests/useWatchImpulse/watching-conditional-impulse.spec.ts
@@ -68,7 +68,7 @@ describe.each([
         })
 
         expect(result.current).toStrictEqual({ count: 1 })
-        expect(impulse).toHaveProperty("emitters.size", 1)
+        expect(impulse).toHaveEmittersSize(1)
       })
 
       it("should return updated Impulse's value", () => {
@@ -82,7 +82,7 @@ describe.each([
           impulse.setValue({ count: 2 })
         })
         expect(result.current).toStrictEqual({ count: 2 })
-        expect(impulse).toHaveProperty("emitters.size", 1)
+        expect(impulse).toHaveEmittersSize(1)
       })
 
       it("should return replaced Impulse's value", () => {
@@ -92,15 +92,15 @@ describe.each([
         const { result, rerender } = renderHook(useHook, {
           initialProps: { impulse: impulse_1, isActive: true },
         })
-        expect(impulse_1).toHaveProperty("emitters.size", 1)
-        expect(impulse_2).toHaveProperty("emitters.size", 0)
+        expect(impulse_1).toHaveEmittersSize(1)
+        expect(impulse_2).toHaveEmittersSize(0)
 
         act(() => {
           rerender({ impulse: impulse_2, isActive: true })
         })
         expect(result.current).toStrictEqual({ count: 10 })
-        expect(impulse_1).toHaveProperty("emitters.size", 0)
-        expect(impulse_2).toHaveProperty("emitters.size", 1)
+        expect(impulse_1).toHaveEmittersSize(0)
+        expect(impulse_2).toHaveEmittersSize(1)
 
         act(() => {
           impulse_2.setValue({ count: 20 })
@@ -111,8 +111,8 @@ describe.each([
           impulse_1.setValue({ count: 2 })
         })
         expect(result.current).toStrictEqual({ count: 20 })
-        expect(impulse_1).toHaveProperty("emitters.size", 0)
-        expect(impulse_2).toHaveProperty("emitters.size", 1)
+        expect(impulse_1).toHaveEmittersSize(0)
+        expect(impulse_2).toHaveEmittersSize(1)
       })
 
       it("should return fallback value when turns inactive", () => {
@@ -123,7 +123,7 @@ describe.each([
 
         rerender({ impulse: impulse, isActive: false })
         expect(result.current).toStrictEqual({ count: -1 })
-        expect(impulse).toHaveProperty("emitters.size", 0)
+        expect(impulse).toHaveEmittersSize(0)
       })
     })
 
@@ -135,7 +135,7 @@ describe.each([
         })
 
         expect(result.current).toStrictEqual({ count: -1 })
-        expect(impulse).toHaveProperty("emitters.size", 0)
+        expect(impulse).toHaveEmittersSize(0)
       })
 
       it("should return fallback value when inactive when impulse updates", () => {
@@ -148,7 +148,7 @@ describe.each([
           impulse.setValue({ count: 2 })
         })
         expect(result.current).toStrictEqual({ count: -1 })
-        expect(impulse).toHaveProperty("emitters.size", 0)
+        expect(impulse).toHaveEmittersSize(0)
       })
 
       it("should return Impulse's value when turns active", () => {
@@ -159,13 +159,13 @@ describe.each([
 
         rerender({ impulse: impulse, isActive: true })
         expect(result.current).toStrictEqual({ count: 1 })
-        expect(impulse).toHaveProperty("emitters.size", 1)
+        expect(impulse).toHaveEmittersSize(1)
 
         act(() => {
           impulse.setValue({ count: 2 })
         })
         expect(result.current).toStrictEqual({ count: 2 })
-        expect(impulse).toHaveProperty("emitters.size", 1)
+        expect(impulse).toHaveEmittersSize(1)
       })
 
       it("should not trigger the watcher when the impulse updates", () => {

--- a/tests/useWatchImpulse/watching-single-impulse.spec.ts
+++ b/tests/useWatchImpulse/watching-single-impulse.spec.ts
@@ -85,10 +85,10 @@ describe.each([
 
       it("stops watching impulse_1 changes after replacement with impulse_2", () => {
         const { impulse_1, impulse_2, result, rerender } = setup()
-        expect(impulse_1).toHaveProperty("emitters.size", 1)
+        expect(impulse_1).toHaveEmittersSize(1)
 
         rerender({ impulse: impulse_2 })
-        expect(impulse_1).toHaveProperty("emitters.size", 0)
+        expect(impulse_1).toHaveEmittersSize(0)
 
         act(() => {
           impulse_1.setValue(Counter.inc)
@@ -96,15 +96,15 @@ describe.each([
 
         expect(impulse_1.getValue()).toStrictEqual({ count: 2 })
         expect(result.current).toStrictEqual({ count: 10 })
-        expect(impulse_1).toHaveProperty("emitters.size", 0)
+        expect(impulse_1).toHaveEmittersSize(0)
       })
 
       it("starts watching impulse_2 changes after replacement of impulse_1", () => {
         const { impulse_1, impulse_2, result, rerender } = setup()
-        expect(impulse_2).toHaveProperty("emitters.size", 0)
+        expect(impulse_2).toHaveEmittersSize(0)
 
         rerender({ impulse: impulse_2 })
-        expect(impulse_2).toHaveProperty("emitters.size", 1)
+        expect(impulse_2).toHaveEmittersSize(1)
 
         act(() => {
           impulse_2.setValue(Counter.inc)
@@ -112,7 +112,7 @@ describe.each([
 
         expect(impulse_1.getValue()).toStrictEqual({ count: 1 })
         expect(result.current).toStrictEqual({ count: 11 })
-        expect(impulse_2).toHaveProperty("emitters.size", 1)
+        expect(impulse_2).toHaveEmittersSize(1)
       })
 
       it("replaces impulse_1 back", () => {
@@ -129,8 +129,8 @@ describe.each([
 
         rerender({ impulse: impulse_2 })
         rerender({ impulse: impulse_1 })
-        expect(impulse_1).toHaveProperty("emitters.size", 1)
-        expect(impulse_2).toHaveProperty("emitters.size", 0)
+        expect(impulse_1).toHaveEmittersSize(1)
+        expect(impulse_2).toHaveEmittersSize(0)
 
         act(() => {
           impulse_2.setValue(Counter.inc)

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,10 +3,9 @@ import { type Options, defineConfig } from "tsup"
 
 // Inspired by https://github.com/egoist/tsup/blob/692c112ac83f463d0be200253466c163c7cee36c/src/plugins/terser.ts
 /**
- * The plugin mangles only annotated properties without minification and mangling anything else.
+ * The plugin mangles only properties starting from single '_' and not ending at '_' without minification and mangling anything else.
  * The annotation looks like
  */
-/*@__MANGLE_PROP__*/
 const manglePlugin: Required<Options>["plugins"][0] = {
   name: "terser-mangle",
   renderChunk: async function (code, info) {
@@ -29,12 +28,12 @@ const manglePlugin: Required<Options>["plugins"][0] = {
           keep_classnames: true,
           keep_fnames: true,
           properties: {
-            regex: /mangle only annotated/,
+            regex: /^_[^_]\w+[^_]$/,
             // @ts-expect-error undocumented, but it specifies how to mangle Impulse's properties
             cache: {
               props: {
-                $value: "_",
-                $emitters: "$",
+                $_value: "_",
+                $_emitters: "$",
               },
             },
           },

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -58,13 +58,10 @@ const manglePlugin: Required<Options>["plugins"][0] = {
 }
 
 export default defineConfig({
-  entryPoints: ["src/index.ts"],
+  entry: ["src/index.ts"],
   format: ["cjs", "esm"],
   dts: true,
   sourcemap: true,
   clean: true,
   plugins: [manglePlugin],
-  terserOptions: {
-    compress: true,
-  },
 })

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -30,10 +30,11 @@ const manglePlugin: Required<Options>["plugins"][0] = {
           keep_fnames: true,
           properties: {
             regex: /mangle only annotated/,
-            // @ts-expect-error undocumented, but it makes emitters to be always mangled as "__"
+            // @ts-expect-error undocumented, but it specifies how to mangle Impulse's properties
             cache: {
               props: {
-                $emitters: "__",
+                $value: "_",
+                $emitters: "$",
               },
             },
           },


### PR DESCRIPTION
Since there is mangling being introduced in #465 it makes a lot of sense to run tests against the mangled dist files, so it makes sure that this operation didn't ruin public or shared API.