### PR TITLE
Drop Impulse#setValue compare arg

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,6 +2,6 @@
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "access": "public",
-  "baseBranch": "master",
+  "baseBranch": "origin/master",
   "commit": false
 }

--- a/.changeset/thick-horses-grab.md
+++ b/.changeset/thick-horses-grab.md
@@ -1,0 +1,8 @@
+---
+"react-impulse": major
+---
+
+Drop the `compare` argument from `Impulse#setValue`.
+
+Turns that that on practice that argument is hardly ever used, but it makes the Impulse API more complicated than it needs to be.
+Instead, the compare function might be defined in the `Impulse.of(initialValue, compare)` fabric or `useImpulse(initialValue, compare)` hook.

--- a/README.md
+++ b/README.md
@@ -139,16 +139,12 @@ count.getValue((x) => x > 0) // === true
 ```dart
 Impulse<T>#setValue(
   valueOrTransform: T | ((currentValue: T) => T),
-  compare?: null | Compare<T>
 ): void
 ```
 
 An `Impulse` instance's method to update the value. All listeners registered via the [`Impulse#subscribe`][impulse__subscribe] method execute whenever the value updates.
 
 - `valueOrTransform` is the new value or a function that transforms the current value.
-- `[compare]` is an optional [`Compare`][compare] function applied for this call only.
-  When not defined the [`Impulse#compare`][impulse__compare] function of the instance will be used.
-  When `null` the [`Object.is`][object_is] function applies to compare the values.
 
 ```ts
 const isActive = Impulse.of(false)

--- a/src/Impulse.ts
+++ b/src/Impulse.ts
@@ -163,24 +163,18 @@ class Impulse<T> {
    * All listeners registered via the `Impulse#subscribe` method execute whenever the Impulse's value updates.
    *
    * @param valueOrTransform either the new value or a function that transforms the current value.
-   * @param compare an optional `Compare` function applied for this call only. When not defined the `Impulse#compare` function will be used. When `null` the `Object.is` function applies to compare the values.
    *
    * @returns `void` to emphasize that Impulses are mutable.
    *
    * @version 1.0.0
    */
-  public setValue(
-    valueOrTransform: T | ((currentValue: T) => T),
-    compare: null | Compare<T> = this.compare,
-  ): void {
-    const finalCompare = compare ?? eq
-
+  public setValue(valueOrTransform: T | ((currentValue: T) => T)): void {
     ScopeEmitter._schedule(() => {
       const nextValue = isFunction(valueOrTransform)
         ? valueOrTransform(this._value)
         : valueOrTransform
 
-      if (finalCompare(this._value, nextValue)) {
+      if (this.compare(this._value, nextValue)) {
         return null
       }
 

--- a/tests/hooks-in-components/single-impulse.spec.tsx
+++ b/tests/hooks-in-components/single-impulse.spec.tsx
@@ -34,7 +34,7 @@ describe("single impulse", () => {
         <button
           type="button"
           data-testid="reset"
-          onClick={() => counter.setValue({ count: 0 }, Counter.compare)}
+          onClick={() => counter.setValue({ count: 0 })}
         />
       </div>
     </React.Profiler>
@@ -104,7 +104,7 @@ describe("single impulse", () => {
     fireEvent.click(screen.getByTestId("reset"))
     expect(onRootRender).not.toHaveBeenCalled()
     expect(onSetterRender).not.toHaveBeenCalled()
-    expect(onGetterRender).not.toHaveBeenCalled()
+    expect(onGetterRender).toHaveBeenCalledOnce()
     expect(screen.getByTestId("getter")).toHaveTextContent("0")
     vi.clearAllMocks()
 

--- a/tests/useWatchImpulse/watching-single-impulse.spec.ts
+++ b/tests/useWatchImpulse/watching-single-impulse.spec.ts
@@ -142,7 +142,7 @@ describe.each([
   })
 })
 
-describe("transform Impulse's value inside watcher", () => {
+describe("transform watched Impulse's", () => {
   const toTuple = ({ count }: Counter): [boolean, boolean] => {
     return [count > 2, count < 5]
   }
@@ -332,7 +332,7 @@ describe("transform Impulse's value inside watcher", () => {
           },
         ],
       ])("should not trigger the watcher %s", () => {
-        const impulse = Impulse.of({ count: 1 })
+        const impulse = Impulse.of({ count: 1 }, Counter.compare)
         const spy = vi.fn()
 
         renderHook(useHookWithoutCompare, {
@@ -340,12 +340,13 @@ describe("transform Impulse's value inside watcher", () => {
         })
 
         expect(spy).toHaveBeenCalledOnce()
+        vi.clearAllMocks()
 
         act(() => {
-          impulse.setValue(Counter.clone, Counter.compare)
+          impulse.setValue(Counter.clone)
         })
 
-        expect(spy).toHaveBeenCalledOnce()
+        expect(spy).not.toHaveBeenCalled()
       })
     },
   )
@@ -448,15 +449,12 @@ describe("multiple Impulse#getValue() calls", () => {
           expect(spySingle).toHaveBeenCalledTimes(spyDouble.mock.calls.length)
         })
 
-        it.each([
-          ["without Impulse#setValue comparator", undefined],
-          ["with Impulse#setValue comparator", Counter.compare],
-        ])("increments %s", (___, compare) => {
+        it("increments %s", () => {
           const { impulse, spySingle, spyDouble, resultSingle, resultDouble } =
             setup()
 
           act(() => {
-            impulse.setValue(Counter.inc, compare)
+            impulse.setValue(Counter.inc)
           })
 
           expect(resultSingle.current).toStrictEqual({ count: 2 })
@@ -464,15 +462,12 @@ describe("multiple Impulse#getValue() calls", () => {
           expect(spySingle).toHaveBeenCalledTimes(spyDouble.mock.calls.length)
         })
 
-        it.each([
-          ["without Impulse#setValue comparator", undefined],
-          ["with Impulse#setValue comparator", Counter.compare],
-        ])("clones %s", (___, compare) => {
+        it("clones %s", () => {
           const { impulse, spySingle, spyDouble, resultSingle, resultDouble } =
             setup()
 
           act(() => {
-            impulse.setValue(Counter.clone, compare)
+            impulse.setValue(Counter.clone)
           })
 
           expect(resultSingle.current).toStrictEqual({ count: 1 })


### PR DESCRIPTION

Drop the `compare` argument from `Impulse#setValue`.

Turns that that on practice that argument is hardly ever used, but it makes the Impulse API more complicated than it needs to be.
Instead, the compare function might be defined in the `Impulse.of(initialValue, compare)` fabric or `useImpulse(initialValue, compare)` hook.
