### PR TITLE
Make the `Impulse#compare` property private.

### DIFF
--- a/.changeset/thick-horses-grab.md
+++ b/.changeset/thick-horses-grab.md
@@ -4,5 +4,5 @@
 
 Drop the `compare` argument from `Impulse#setValue`.
 
-Turns that that on practice that argument is hardly ever used, but it makes the Impulse API confusing: why specifically `compare` is passed to `setValue` and not to `Impulse#of` or `useImpulse`?
+Turns that that in practice that argument is hardly ever used, but it makes the Impulse API confusing: why specifically `compare` is passed to `setValue` and not to `Impulse#of` or `useImpulse`?
 So, when needed, defined `compare` in `Impulse.of(initialValue, compare)` fabric or `useImpulse(initialValue, compare)` hook.

--- a/.changeset/thick-horses-grab.md
+++ b/.changeset/thick-horses-grab.md
@@ -4,5 +4,5 @@
 
 Drop the `compare` argument from `Impulse#setValue`.
 
-Turns that that on practice that argument is hardly ever used, but it makes the Impulse API more complicated than it needs to be.
-Instead, the compare function might be defined in the `Impulse.of(initialValue, compare)` fabric or `useImpulse(initialValue, compare)` hook.
+Turns that that on practice that argument is hardly ever used, but it makes the Impulse API confusing: why specifically `compare` is passed to `setValue` and not to `Impulse#of` or `useImpulse`?
+So, when needed, defined `compare` in `Impulse.of(initialValue, compare)` fabric or `useImpulse(initialValue, compare)` hook.

--- a/.changeset/three-seas-remain.md
+++ b/.changeset/three-seas-remain.md
@@ -4,5 +4,5 @@
 
 Make the `Impulse#compare` property private.
 
-Turns that that on practice that property is hardly ever used, so now and it becomes private.
+Turns that that in practice that property is hardly ever used, so now and it becomes private.
 But you still can specify `Impulse#compare` via `Impulse.of(initialValue, compare)` fabric or `useImpulse(initialValue, compare)` hook.

--- a/.changeset/three-seas-remain.md
+++ b/.changeset/three-seas-remain.md
@@ -1,0 +1,8 @@
+---
+"react-impulse": major
+---
+
+Make the `Impulse#compare` property private.
+
+Turns that that on practice that property is hardly ever used, so now and it becomes private.
+But you still can specify `Impulse#compare` via `Impulse.of(initialValue, compare)` fabric or `useImpulse(initialValue, compare)` hook.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Impulse.of<T>(
 A static method that creates new Impulse.
 
 - `[initialValue]` is an optional initial value. If not defined, the Impulse's value is `undefined` but it still can specify the value's type.
-- `[compare]` is an optional [`Compare`][compare] function applied as [`Impulse#compare`][impulse__compare]. When not defined or `null` then [`Object.is`][object_is] applies as a fallback.
+- `[compare]` is an optional [`Compare`][compare] function that determines whether the value has changed. When not defined or `null` then [`Object.is`][object_is] applies as a fallback.
 
 > 💡 The [`useImpulse`][use_impulse] hook helps to create and store an `Impulse` inside a React component.
 
@@ -172,8 +172,8 @@ Impulse<T>#clone(
 An `Impulse` instance's method for cloning an Impulse.
 
 - `[transform]` is an optional function that applies to the current value before cloning. It might be handy when cloning mutable values.
-- `[compare]` is an optional [`Compare`][compare] function applied as [`Impulse#compare`][impulse__compare].
-  When not defined, it uses the [`Impulse#compare`][impulse__compare] function from the origin.
+- `[compare]` is an optional [`Compare`][compare] function that determines whether the value has changed.
+  When not defined, it uses the `compare` function from the origin Impulse.
   When `null` the [`Object.is`][object_is] function applies to compare the values.
 
 ```ts
@@ -191,14 +191,6 @@ const cloneOfMutable = mutable.clone((current) => ({
   blacklist: new Set(current.blacklist),
 }))
 ```
-
-### `Impulse#compare`
-
-```dart
-Impulse<T>#compare: Compare<T>
-```
-
-The [`Compare`][compare] function compares the Impulse's value with the new value given via [`Impulse#setValue`][impulse__set_value]. Whenever the function returns `true`, neither the value change nor it notifies the listeners subscribed via [`Impulse#subscribe`][impulse__subscribe].
 
 ### `Impulse#subscribe`
 
@@ -320,11 +312,11 @@ function useImpulse<T>(
 ```
 
 - `[valueOrInitValue]` is an optional value used during the initial render. If the initial value is the result of an expensive computation, you may provide a function instead, which will be executed only on the initial render. If not defined, the Impulse's value is `undefined` but it still can specify the value's type.
-- `[compare]` is an optional [`Compare`][compare] function applied as [`Impulse#compare`][impulse__compare]. When not defined or `null` then [`Object.is`][object_is] applies as a fallback.
+- `[compare]` is an optional [`Compare`][compare] function that determines whether the value has changed. When not defined or `null` then [`Object.is`][object_is] applies as a fallback.
 
 A hook that initiates a stable (never changing) Impulse.
 
-> 💬 The initial value is disregarded during subsequent re-renders.
+> 💬 The initial value is disregarded during subsequent re-renders but compare function is not - it uses the latest function passed to the hook.
 
 ```ts
 const count = useImpulse(0) // Impulse<number>
@@ -682,7 +674,6 @@ A function that compares two values and returns `true` if they are equal. Depend
 <!-- L I N K S -->
 
 [impulse__of]: #impulseof
-[impulse__compare]: #impulsecompare
 [impulse__clone]: #impulseclone
 [impulse__get_value]: #impulsegetvalue
 [impulse__set_value]: #impulsesetvalue

--- a/src/Impulse.ts
+++ b/src/Impulse.ts
@@ -62,20 +62,10 @@ class Impulse<T> {
 
   private readonly _emitters = new Set<ScopeEmitter>()
 
-  /**
-   * The `Compare` function compares Impulse's value with the new value given via `Impulse#setValue`.
-   * Whenever the function returns `true`, neither the value change nor it notifies the listeners subscribed via `Impulse#subscribe`.
-   *
-   * @version 1.0.0
-   */
-  public readonly compare: Compare<T>
-
   private constructor(
     private _value: T,
-    compare: Compare<T>,
-  ) {
-    this.compare = compare
-  }
+    private readonly _compare: Compare<T>,
+  ) {}
 
   /**
    * Return the value when serializing to JSON.
@@ -115,7 +105,7 @@ class Impulse<T> {
    */
   public clone(
     transform?: (value: T) => T,
-    compare: null | Compare<T> = this.compare,
+    compare: null | Compare<T> = this._compare,
   ): Impulse<T> {
     return new Impulse(
       isFunction(transform) ? transform(this._value) : this._value,
@@ -174,7 +164,7 @@ class Impulse<T> {
         ? valueOrTransform(this._value)
         : valueOrTransform
 
-      if (this.compare(this._value, nextValue)) {
+      if (this._compare(this._value, nextValue)) {
         return null
       }
 

--- a/src/Impulse.ts
+++ b/src/Impulse.ts
@@ -32,27 +32,17 @@ class Impulse<T> {
    * Creates new Impulse.
    *
    * @param initialValue the initial value.
-   * @param compare an optional `Compare` function applied as `Impulse#compare`. When not defined or `null` then `Object.is` applies as a fallback.
+   * @param compare an optional `Compare` function that determines whether the value has changed. When not defined or `null` then `Object.is` applies as a fallback.
    *
    * @version 1.0.0
    */
   public static of<T>(initialValue: T, compare?: null | Compare<T>): Impulse<T>
 
-  // Implements 👆
   @validate
     ._when("subscribe", SUBSCRIBE_CALLING_IMPULSE_OF)
     ._when("useWatchImpulse", USE_WATCH_IMPULSE_CALLING_IMPULSE_OF)
     ._when("useImpulseMemo", USE_IMPULSE_MEMO_CALLING_IMPULSE_OF)
     ._alert()
-
-  /**
-   * Creates new Impulse.
-   *
-   * @param initialValue an optional initial value.
-   * @param compare an optional `Compare` function applied as `Impulse#compare`. When not defined or `null` then `Object.is` applies as a fallback.
-   *
-   * @version 1.0.0
-   */
   public static of<T>(
     initialValue?: T,
     compare?: null | Compare<undefined | T>,
@@ -90,19 +80,19 @@ class Impulse<T> {
     return String(this.getValue())
   }
 
+  /**
+   * Clones an Impulse. You can specify the `compare` function of the new Impulse.
+   *
+   * @param transform an optional function that applies to the current value before cloning. It might be handy when cloning mutable values.
+   * @param compare an optional `Compare` function that determines whether the value has changed. When not defined, it uses the `compare` function from the origin Impulse. When `null` the `Object.is` function applies to compare the values.
+   *
+   * @version 1.0.0
+   */
   @validate
     ._when("subscribe", SUBSCRIBE_CALLING_IMPULSE_CLONE)
     ._when("useWatchImpulse", USE_WATCH_IMPULSE_CALLING_IMPULSE_CLONE)
     ._when("useImpulseMemo", USE_IMPULSE_MEMO_CALLING_IMPULSE_CLONE)
     ._alert()
-  /**
-   * Clones an Impulse.
-   *
-   * @param transform an optional function that applies to the current value before cloning. It might be handy when cloning mutable values.
-   * @param compare an optional `Compare` function applied as `Impulse#compare`. When not defined, it uses the `Impulse#compare` function from the origin. When `null` the `Object.is` function applies to compare the values.
-   *
-   * @version 1.0.0
-   */
   public clone(
     transform?: (value: T) => T,
     compare: null | Compare<T> = this._compare,
@@ -128,13 +118,6 @@ class Impulse<T> {
    */
   public getValue<R>(select: (value: T) => R): R
 
-  /**
-   * Returns a value selected from the current value.
-   *
-   * @param select an optional function that applies to the current value before returning.
-   *
-   * @version 1.0.0
-   */
   public getValue<R>(select?: (value: T) => R): T | R {
     const scope = extractScope()
 
@@ -143,11 +126,6 @@ class Impulse<T> {
     return isFunction(select) ? select(this._value) : this._value
   }
 
-  @validate
-    ._when("watch", WATCH_CALLING_IMPULSE_SET_VALUE)
-    ._when("useWatchImpulse", USE_WATCH_IMPULSE_CALLING_IMPULSE_SET_VALUE)
-    ._when("useImpulseMemo", USE_IMPULSE_MEMO_CALLING_IMPULSE_SET_VALUE)
-    ._prevent()
   /**
    * Updates the value.
    * All listeners registered via the `Impulse#subscribe` method execute whenever the Impulse's value updates.
@@ -158,6 +136,11 @@ class Impulse<T> {
    *
    * @version 1.0.0
    */
+  @validate
+    ._when("watch", WATCH_CALLING_IMPULSE_SET_VALUE)
+    ._when("useWatchImpulse", USE_WATCH_IMPULSE_CALLING_IMPULSE_SET_VALUE)
+    ._when("useImpulseMemo", USE_IMPULSE_MEMO_CALLING_IMPULSE_SET_VALUE)
+    ._prevent()
   public setValue(valueOrTransform: T | ((currentValue: T) => T)): void {
     ScopeEmitter._schedule(() => {
       const nextValue = isFunction(valueOrTransform)
@@ -174,12 +157,6 @@ class Impulse<T> {
     })
   }
 
-  @validate
-    ._when("watch", WATCH_CALLING_IMPULSE_SUBSCRIBE)
-    ._when("subscribe", SUBSCRIBE_CALLING_IMPULSE_SUBSCRIBE)
-    ._when("useWatchImpulse", USE_WATCH_IMPULSE_CALLING_IMPULSE_SUBSCRIBE)
-    ._when("useImpulseMemo", USE_IMPULSE_MEMO_CALLING_IMPULSE_SUBSCRIBE)
-    ._prevent(noop)
   /**
    * Subscribes to the value's updates caused by calling `Impulse#setValue`.
    *
@@ -191,6 +168,12 @@ class Impulse<T> {
    *
    * @deprecated The method is deprecated in favor of the `subscribe` higher-order function. It will be removed in the next major release.
    */
+  @validate
+    ._when("watch", WATCH_CALLING_IMPULSE_SUBSCRIBE)
+    ._when("subscribe", SUBSCRIBE_CALLING_IMPULSE_SUBSCRIBE)
+    ._when("useWatchImpulse", USE_WATCH_IMPULSE_CALLING_IMPULSE_SUBSCRIBE)
+    ._when("useImpulseMemo", USE_IMPULSE_MEMO_CALLING_IMPULSE_SUBSCRIBE)
+    ._prevent(noop)
   public subscribe(listener: VoidFunction): VoidFunction {
     const emitter = new ScopeEmitter(false)
 

--- a/src/useImpulse.ts
+++ b/src/useImpulse.ts
@@ -16,7 +16,7 @@ function useImpulse<T = undefined>(): Impulse<undefined | T>
  * *The initial value is disregarded during subsequent re-renders.*
  *
  * @param valueOrInitValue either an initial value or function returning an initial value during the initial render
- * @param compare an optional `Compare` function applied as `Impulse#compare`. When not defined or `null` then `Object.is` applies as a fallback.
+ * @param compare an optional `Compare` function that determines whether the value has changed. When not defined or `null` then `Object.is` applies as a fallback.
  *
  * @version 1.0.0
  */
@@ -25,7 +25,6 @@ function useImpulse<T>(
   compare?: null | Compare<T>,
 ): Impulse<T>
 
-// Implements 👆
 function useImpulse<T>(
   valueOrInitValue?: T | ((...args: []) => T),
   compare?: null | Compare<undefined | T>,

--- a/src/useImpulseValue.ts
+++ b/src/useImpulseValue.ts
@@ -13,7 +13,7 @@ import { useWatchImpulse } from "./useWatchImpulse"
  */
 function useImpulseValue<T>(impulse: Impulse<T>): T {
   const watcher = useCallback(() => impulse.getValue(), [impulse])
-  const value = useWatchImpulse(watcher, impulse.compare)
+  const value = useWatchImpulse(watcher)
 
   useDebugValue(value)
 

--- a/tests/Impulse.spec.ts
+++ b/tests/Impulse.spec.ts
@@ -29,10 +29,9 @@ describe("Impulse.of()", () => {
 
 describe("Impulse#compare", () => {
   it("does not call compare on init", () => {
-    const compare = vi.fn(Counter.compare)
-    Impulse.of({ count: 0 }, compare)
+    Impulse.of({ count: 0 }, Counter.compare)
 
-    expect(compare).not.toHaveBeenCalled()
+    expect(Counter.compare).not.toHaveBeenCalled()
   })
 
   describe("when creating an impulse with Impulse.of", () => {
@@ -381,20 +380,19 @@ describe("Impulse#subscribe", () => {
 
   it("does not emit when a new value is comparably equal", () => {
     const spy = vi.fn()
-    const spyCompare = vi.fn(Counter.compare)
-    const impulse = Impulse.of({ count: 0 }, spyCompare)
+    const impulse = Impulse.of({ count: 0 }, Counter.compare)
     const unsubscribe = impulse.subscribe(spy)
 
     impulse.setValue(Counter.clone)
     expect(spy).not.toHaveBeenCalled()
-    expect(spyCompare).toHaveBeenCalledOnce()
-    expect(spyCompare).toHaveLastReturnedWith(true)
+    expect(Counter.compare).toHaveBeenCalledOnce()
+    expect(Counter.compare).toHaveLastReturnedWith(true)
     vi.clearAllMocks()
 
     impulse.setValue(Counter.clone)
     expect(spy).not.toHaveBeenCalled()
-    expect(spyCompare).toHaveBeenCalledOnce()
-    expect(spyCompare).toHaveLastReturnedWith(true)
+    expect(Counter.compare).toHaveBeenCalledOnce()
+    expect(Counter.compare).toHaveLastReturnedWith(true)
     vi.clearAllMocks()
 
     unsubscribe()

--- a/tests/Impulse.spec.ts
+++ b/tests/Impulse.spec.ts
@@ -39,48 +39,73 @@ describe("Impulse#compare", () => {
     it("assigns Object.is by default", () => {
       const impulse = Impulse.of({ count: 0 })
 
-      expect(impulse.compare).toBe(Object.is)
+      impulse.setValue({ count: 1 })
+      expect(Object.is).toHaveBeenCalledOnce()
+      expect(Object.is).toHaveBeenLastCalledWith({ count: 0 }, { count: 1 })
     })
 
     it("assigns Object.is by `null`", () => {
       const impulse = Impulse.of({ count: 0 }, null)
 
-      expect(impulse.compare).toBe(Object.is)
+      impulse.setValue({ count: 1 })
+      expect(Object.is).toHaveBeenCalledOnce()
+      expect(Object.is).toHaveBeenLastCalledWith({ count: 0 }, { count: 1 })
     })
 
     it("assigns custom function", () => {
       const impulse = Impulse.of({ count: 0 }, Counter.compare)
 
-      expect(impulse.compare).toBe(Counter.compare)
+      impulse.setValue({ count: 1 })
+      expect(Counter.compare).toHaveBeenCalledOnce()
+      expect(Counter.compare).toHaveBeenLastCalledWith(
+        { count: 0 },
+        { count: 1 },
+      )
     })
   })
 
   describe("when creating an impulse with Impulse.clone", () => {
     it("inherits default the source impulse compare", () => {
-      const impulse = Impulse.of({ count: 0 })
+      const clone = Impulse.of({ count: 0 }).clone()
 
-      expect(impulse.clone().compare).toBe(impulse.compare)
-      expect(impulse.clone().compare).toBe(Object.is)
+      clone.setValue({ count: 1 })
+      expect(Object.is).toHaveBeenCalledOnce()
+      expect(Object.is).toHaveBeenLastCalledWith({ count: 0 }, { count: 1 })
     })
 
     it("inherits custom the source impulse compare", () => {
-      const impulse = Impulse.of({ count: 0 }, Counter.compare)
+      const clone = Impulse.of({ count: 0 }, Counter.compare).clone()
 
-      expect(impulse.clone().compare).toBe(impulse.compare)
-      expect(impulse.clone().compare).toBe(Counter.compare)
+      clone.setValue({ count: 1 })
+      expect(Counter.compare).toHaveBeenCalledOnce()
+      expect(Counter.compare).toHaveBeenLastCalledWith(
+        { count: 0 },
+        { count: 1 },
+      )
     })
 
     it("assigns Object.is by `null`", () => {
-      const impulse = Impulse.of({ count: 0 }, Counter.compare)
+      const clone = Impulse.of({ count: 0 }, Counter.compare).clone(
+        Counter.clone,
+        null,
+      )
 
-      expect(impulse.clone(Counter.clone, null).compare).toBe(Object.is)
+      clone.setValue({ count: 1 })
+      expect(Object.is).toHaveBeenCalledOnce()
+      expect(Object.is).toHaveBeenLastCalledWith({ count: 0 }, { count: 1 })
     })
 
     it("assigns custom function", () => {
-      const impulse = Impulse.of({ count: 0 })
-
-      expect(impulse.clone(Counter.clone, Counter.compare).compare).toBe(
+      const clone = Impulse.of({ count: 0 }).clone(
+        Counter.clone,
         Counter.compare,
+      )
+
+      clone.setValue({ count: 1 })
+      expect(Counter.compare).toHaveBeenCalledOnce()
+      expect(Counter.compare).toHaveBeenLastCalledWith(
+        { count: 0 },
+        { count: 1 },
       )
     })
   })

--- a/tests/common.ts
+++ b/tests/common.ts
@@ -12,12 +12,16 @@ export {
 
 import type { Compare, Impulse } from "../src"
 
+afterEach(() => {
+  Counter.compare.mockClear()
+})
+
 abstract class Counter {
   public abstract readonly count: number
 
-  public static compare: Compare<Counter> = (prev, next) => {
+  public static compare = vi.fn((prev, next) => {
     return prev.count === next.count
-  }
+  }) satisfies Compare<Counter>
 
   public static merge(left: Counter, right: Counter, ...rest: Array<Counter>) {
     return {


### PR DESCRIPTION
Make the `Impulse#compare` property private.

Turns that that in practice that property is hardly ever used, so now and it becomes private.
But you still can specify `Impulse#compare` via `Impulse.of(initialValue, compare)` fabric or `useImpulse(initialValue, compare)` hook.