### PR TITLE
Introduce dependencies for useWatchImpulse

### DIFF
--- a/.changeset/loud-lamps-fry.md
+++ b/.changeset/loud-lamps-fry.md
@@ -1,0 +1,31 @@
+---
+"react-impulse": major
+---
+
+Introduce dependencies optional argument for `useWatchImpulse`:
+
+```dart
+function useWatchImpulse<T>(
+  watcher: () => T,
+  dependencies?: DependencyList,
+  options?: UseWatchImpulseOptions<T>
+): T
+```
+
+It works the same way as `useEffect` dependencies argument - if the dependencies are not defined, the `watcher` will be called on every render. Otherwise, it will be called only when the dependencies change.
+
+```ts
+const impulse = useImpulse(0)
+
+// before
+const count = useWatchImpulse(
+  useCallback(() => {
+    return impulse.getValue()
+  }, [impulse]),
+)
+
+// now
+const count = useWatchImpulse(() => {
+  return impulse.getValue()
+}, [impulse])
+```

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -173,7 +173,7 @@
         "react-hooks/exhaustive-deps": [
           "error",
           {
-            "additionalHooks": "(use(\\w+)(Memo|Effect)|useTransmittingImpulse)"
+            "additionalHooks": "(use(\\w+)(Memo|Effect)|useWatchImpulse|useTransmittingImpulse)"
           }
         ],
 

--- a/README.md
+++ b/README.md
@@ -542,11 +542,13 @@ A hook that initialize a stable (never changing) transmitting Impulse. Look at t
 ```dart
 function useWatchImpulse<T>(
   watcher: () => T,
+  dependencies?: DependencyList,
   options?: UseWatchImpulseOptions<T>
 ): T
 ```
 
 - `watcher` is a function that subscribes to all Impulses calling the [`Impulse#getValue`][impulse__get_value] method inside the function.
+- `dependencies` is an optional array of dependencies of the `watcher` function. If not defined, the `watcher` function is called on every render.
 - `[options]` is an optional [`UseWatchImpulseOptions`][use_watch_impulse_options] object.
 
 The `useWatchImpulse` hook is an alternative to the [`watch`][watch] function. It executes the `watcher` function whenever any of the involved Impulses' value update but enqueues a re-render only when the resulting value is different from the previous.
@@ -591,8 +593,6 @@ const Challenge: React.FC = () => {
 ```
 
 > 💬 The `watcher` function is only for reading the Impulses' values. It should never call [`Impulse.of`][impulse__of], [`Impulse#clone`][impulse__clone], or [`Impulse#setValue`][impulse__set_value] methods inside.
-
-> 💡 It is recommended to memoize the `watcher` function with [`React.useCallback`][react__use_callback] for better performance.
 
 > 💡 Keep in mind that the `watcher` function acts as a "reader" so you'd like to avoid heavy computations inside it. Sometimes it might be a good idea to pass a watcher result to a separated memoization hook. The same is true for the `compare` function - you should choose wisely between avoiding extra re-renders and heavy comparisons.
 
@@ -892,7 +892,7 @@ Want to see ESLint suggestions for the dependencies? Add the hook name to the ES
   "react-hooks/exhaustive-deps": [
     "error",
     {
-      "additionalHooks": "(useTransmittingImpulse|useImpulse(Effect|LayoutEffect|Memo|Callback))"
+      "additionalHooks": "(useTransmittingImpulse|useWatchImpulse|useImpulse(Effect|LayoutEffect|Memo|Callback))"
     }
   ]
 }

--- a/src/useWatchImpulse.ts
+++ b/src/useWatchImpulse.ts
@@ -22,7 +22,7 @@ interface UseWatchImpulseOptions<T> {
  * but enqueues a re-render only when the resulting value is different from the previous.
  *
  * @param watcher a function that subscribes to all Impulses calling the `Impulse#getValue` method inside the function.
- * @param dependencies optional array of dependencies of the `watcher` function. If not defined, the `watcher` function is called on every re-render.
+ * @param dependencies optional array of dependencies of the `watcher` function. If not defined, the `watcher` function is called on every render.
  * @param options optional `UseWatchImpulseOptions`.
  *
  * @version 1.0.0

--- a/src/useWatchImpulse.ts
+++ b/src/useWatchImpulse.ts
@@ -1,6 +1,6 @@
 export { type UseWatchImpulseOptions, useWatchImpulse }
 
-import { useCallback, useDebugValue } from "./dependencies"
+import { type DependencyList, useCallback, useDebugValue } from "./dependencies"
 import { type Compare, eq, useEvent } from "./utils"
 import { useScope } from "./useScope"
 import { defineExecutionContext } from "./validation"
@@ -22,12 +22,14 @@ interface UseWatchImpulseOptions<T> {
  * but enqueues a re-render only when the resulting value is different from the previous.
  *
  * @param watcher a function that subscribes to all Impulses calling the `Impulse#getValue` method inside the function.
+ * @param dependencies optional array of dependencies of the `watcher` function. If not defined, the `watcher` function is called on every re-render.
  * @param options optional `UseWatchImpulseOptions`.
  *
  * @version 1.0.0
  */
 function useWatchImpulse<T>(
   watcher: () => T,
+  dependencies?: DependencyList,
   { compare }: UseWatchImpulseOptions<T> = {},
 ): T {
   const transform = useCallback(
@@ -39,7 +41,8 @@ function useWatchImpulse<T>(
         watcher,
       )
     },
-    [watcher],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    dependencies ?? [watcher],
   )
   const value = useScope(transform, useEvent(compare ?? eq))
 

--- a/tests/useWatchImpulse/watcher-comparator.spec.ts
+++ b/tests/useWatchImpulse/watcher-comparator.spec.ts
@@ -1,39 +1,28 @@
-import { useCallback } from "react"
 import { act, renderHook } from "@testing-library/react"
 
-import { type Compare, Impulse, useWatchImpulse } from "../../src"
+import { Impulse, useWatchImpulse } from "../../src"
 import { Counter, type WithCompare, type WithImpulse } from "../common"
 
-describe.each([
-  [
-    "inline watcher",
-    ({ impulse }: WithImpulse, compare?: Compare<Counter>) => {
-      return useWatchImpulse(() => impulse.getValue(), { compare })
-    },
-  ],
-  [
-    "memoized watcher",
-    ({ impulse }: WithImpulse, compare?: Compare<Counter>) => {
-      return useWatchImpulse(
-        useCallback(() => impulse.getValue(), [impulse]),
-        { compare },
-      )
-    },
-  ],
-])("with %s", (_, useHookWithoutCompare) => {
+describe("watcher", () => {
+  const watcher = ({ impulse }: WithImpulse) => impulse.getValue()
+
   describe.each([
     [
       "with inline comparator",
-      ({ compare, ...props }: WithImpulse & WithCompare) => {
+      ({ impulse, compare }: WithImpulse & WithCompare) => {
         const cmp = compare ?? Counter.compare
 
-        return useHookWithoutCompare(props, (prev, next) => cmp(prev, next))
+        return useWatchImpulse(() => watcher({ impulse }), [impulse], {
+          compare: (prev, next) => cmp(prev, next),
+        })
       },
     ],
     [
       "with memoized comparator",
-      ({ compare, ...props }: WithImpulse & WithCompare) => {
-        return useHookWithoutCompare(props, compare ?? Counter.compare)
+      ({ impulse, compare }: WithImpulse & WithCompare) => {
+        return useWatchImpulse(() => watcher({ impulse }), [impulse], {
+          compare: compare ?? Counter.compare,
+        })
       },
     ],
   ])("%s", (__, useHook) => {

--- a/tests/useWatchImpulse/watching-nested-stores.spec.ts
+++ b/tests/useWatchImpulse/watching-nested-stores.spec.ts
@@ -1,7 +1,6 @@
-import { useCallback } from "react"
 import { act, renderHook } from "@testing-library/react"
 
-import { batch, type Compare, Impulse, useWatchImpulse } from "../../src"
+import { batch, Impulse, useWatchImpulse } from "../../src"
 import {
   Counter,
   type WithFirst,
@@ -11,62 +10,48 @@ import {
   type WithThird,
 } from "../common"
 
-describe.each([
-  [
-    "inline watcher",
-    (
-      { impulse }: WithImpulse<WithFirst & WithSecond>,
-      compare?: Compare<Counter>,
-    ) => {
-      return useWatchImpulse(
-        () => {
-          const { first, second } = impulse.getValue()
+describe("nested watcher", () => {
+  const watcher = ({ impulse }: WithImpulse<WithFirst & WithSecond>) => {
+    const { first, second } = impulse.getValue()
 
-          return Counter.merge(first.getValue(), second.getValue())
-        },
-        { compare },
-      )
-    },
-  ],
-  [
-    "memoized watcher",
-    (
-      { impulse }: WithImpulse<WithFirst & WithSecond>,
-      compare?: Compare<Counter>,
-    ) => {
-      return useWatchImpulse(
-        useCallback(() => {
-          const { first, second } = impulse.getValue()
+    return Counter.merge(first.getValue(), second.getValue())
+  }
 
-          return Counter.merge(first.getValue(), second.getValue())
-        }, [impulse]),
-        { compare },
-      )
-    },
-  ],
-])("direct %s", (_, useHookWithoutCompare) => {
   describe.each([
-    ["without comparator", useHookWithoutCompare],
+    [
+      "without deps",
+      ({ impulse }: WithImpulse<WithFirst & WithSecond>) => {
+        return useWatchImpulse(() => watcher({ impulse }))
+      },
+    ],
+    [
+      "without comparator",
+      ({ impulse }: WithImpulse<WithFirst & WithSecond>) => {
+        return useWatchImpulse(() => watcher({ impulse }), [impulse])
+      },
+    ],
     [
       "with inline comparator",
-      (props: WithImpulse<WithFirst & WithSecond>) => {
-        return useHookWithoutCompare(props, (prev, next) =>
-          Counter.compare(prev, next),
-        )
+      ({ impulse }: WithImpulse<WithFirst & WithSecond>) => {
+        return useWatchImpulse(() => watcher({ impulse }), [impulse], {
+          compare: (prev, next) => Counter.compare(prev, next),
+        })
       },
     ],
     [
       "with memoized comparator",
-      (props: WithImpulse<WithFirst & WithSecond>) => {
-        return useHookWithoutCompare(props, Counter.compare)
+      ({ impulse }: WithImpulse<WithFirst & WithSecond>) => {
+        return useWatchImpulse(() => watcher({ impulse }), [impulse], {
+          compare: Counter.compare,
+        })
       },
     ],
-  ])("%s", (__, useHook) => {
+  ])("%s", (_, useCounter) => {
     const setup = () => {
       const first = Impulse.of({ count: 2 })
       const second = Impulse.of({ count: 3 })
       const impulse = Impulse.of({ first, second })
-      const { result } = renderHook(useHook, {
+      const { result } = renderHook(useCounter, {
         initialProps: { impulse },
       })
 
@@ -136,262 +121,250 @@ describe.each([
   })
 })
 
-describe.each([
-  [
-    "inline watcher",
-    ({ spy, impulse }: WithImpulse & WithSpy, compare?: Compare<Counter>) => {
-      return useWatchImpulse(
-        () => {
-          spy()
+describe("triggering watcher for nested impulses vs single impulse", () => {
+  const watcherSingle = ({ impulse, spy }: WithImpulse & WithSpy) => {
+    spy()
 
-          return impulse.getValue()
-        },
-        { compare },
-      )
-    },
-    (
-      {
+    return impulse.getValue()
+  }
+
+  const watcherNested = ({
+    spy,
+    impulse,
+  }: WithImpulse<WithFirst & WithSecond & WithThird> & WithSpy) => {
+    spy()
+
+    const { first, second, third } = impulse.getValue()
+
+    return Counter.merge(first.getValue(), second.getValue(), third.getValue())
+  }
+
+  describe.each([
+    [
+      "without deps",
+      ({ impulse, spy }: WithImpulse & WithSpy) => {
+        return useWatchImpulse(() => watcherSingle({ impulse, spy }))
+      },
+      ({
         spy,
         impulse,
-      }: WithImpulse<WithFirst & WithSecond & WithThird> & WithSpy,
-      compare?: Compare<Counter>,
-    ) => {
-      return useWatchImpulse(
-        () => {
-          spy()
+      }: WithImpulse<WithFirst & WithSecond & WithThird> & WithSpy) => {
+        return useWatchImpulse(() => watcherNested({ impulse, spy }))
+      },
+    ],
+    [
+      "without comparator",
+      ({ impulse, spy }: WithImpulse & WithSpy) => {
+        return useWatchImpulse(
+          () => watcherSingle({ impulse, spy }),
+          [impulse, spy],
+        )
+      },
+      ({
+        spy,
+        impulse,
+      }: WithImpulse<WithFirst & WithSecond & WithThird> & WithSpy) => {
+        return useWatchImpulse(
+          () => watcherNested({ impulse, spy }),
+          [impulse, spy],
+        )
+      },
+    ],
+    [
+      "with inline comparator",
+      ({ impulse, spy }: WithImpulse & WithSpy) => {
+        return useWatchImpulse(
+          () => watcherSingle({ impulse, spy }),
+          [impulse, spy],
+          {
+            compare: (prev, next) => Counter.compare(prev, next),
+          },
+        )
+      },
+      ({
+        spy,
+        impulse,
+      }: WithImpulse<WithFirst & WithSecond & WithThird> & WithSpy) => {
+        return useWatchImpulse(
+          () => watcherNested({ impulse, spy }),
+          [impulse, spy],
+          {
+            compare: (prev, next) => Counter.compare(prev, next),
+          },
+        )
+      },
+    ],
+    [
+      "with memoized comparator",
+      ({ impulse, spy }: WithImpulse & WithSpy) => {
+        return useWatchImpulse(
+          () => watcherSingle({ impulse, spy }),
+          [impulse, spy],
+          { compare: Counter.compare },
+        )
+      },
+      ({
+        spy,
+        impulse,
+      }: WithImpulse<WithFirst & WithSecond & WithThird> & WithSpy) => {
+        return useWatchImpulse(
+          () => watcherNested({ impulse, spy }),
+          [impulse, spy],
+          { compare: Counter.compare },
+        )
+      },
+    ],
+  ])("%s", (__, useSingleCounter, useNestedCounters) => {
+    const setup = () => {
+      const first = Impulse.of({ count: 1 })
+      const second = Impulse.of({ count: 2 })
+      const third = Impulse.of({ count: 3 })
+      const impulse = Impulse.of({ first, second, third })
+      const spySingle = vi.fn()
+      const spyNested = vi.fn()
 
-          const { first, second, third } = impulse.getValue()
+      const { result: resultSingle } = renderHook(useSingleCounter, {
+        initialProps: { impulse: first, spy: spySingle },
+      })
 
-          return Counter.merge(
-            first.getValue(),
-            second.getValue(),
-            third.getValue(),
-          )
-        },
-        { compare },
-      )
-    },
-  ],
+      const { result: resultNested } = renderHook(useNestedCounters, {
+        initialProps: { impulse, spy: spyNested },
+      })
 
-  [
-    "memoized watcher",
-    ({ spy, impulse }: WithImpulse & WithSpy) => {
-      return useWatchImpulse(
-        useCallback(() => {
-          spy()
-
-          return impulse.getValue()
-        }, [spy, impulse]),
-      )
-    },
-    ({
-      spy,
-      impulse,
-    }: WithImpulse<WithFirst & WithSecond & WithThird> & WithSpy) => {
-      return useWatchImpulse(
-        useCallback(() => {
-          spy()
-
-          const { first, second, third } = impulse.getValue()
-
-          return Counter.merge(
-            first.getValue(),
-            second.getValue(),
-            third.getValue(),
-          )
-        }, [spy, impulse]),
-      )
-    },
-  ],
-])(
-  "triggering %s for nested impulses vs single impulse",
-  (_, useSingleHookWithoutCompare, useMultipleHookWithoutCompare) => {
-    describe.each([
-      [
-        "without comparator",
-        useSingleHookWithoutCompare,
-        useMultipleHookWithoutCompare,
-      ],
-      [
-        "with inline comparator",
-        (props: WithImpulse & WithSpy) => {
-          return useSingleHookWithoutCompare(props, (prev, next) =>
-            Counter.compare(prev, next),
-          )
-        },
-        (props: WithImpulse<WithFirst & WithSecond & WithThird> & WithSpy) => {
-          return useMultipleHookWithoutCompare(props, (prev, next) =>
-            Counter.compare(prev, next),
-          )
-        },
-      ],
-      [
-        "with memoized comparator",
-        (props: WithImpulse & WithSpy) => {
-          return useSingleHookWithoutCompare(props, Counter.compare)
-        },
-        (props: WithImpulse<WithFirst & WithSecond & WithThird> & WithSpy) => {
-          return useMultipleHookWithoutCompare(props, Counter.compare)
-        },
-      ],
-    ])("%s", (__, useSingleHook, useNestedHook) => {
-      const setup = () => {
-        const first = Impulse.of({ count: 1 })
-        const second = Impulse.of({ count: 2 })
-        const third = Impulse.of({ count: 3 })
-        const impulse = Impulse.of({ first, second, third })
-        const spySingle = vi.fn()
-        const spyNested = vi.fn()
-
-        const { result: resultSingle } = renderHook(useSingleHook, {
-          initialProps: { impulse: first, spy: spySingle },
-        })
-
-        const { result: resultNested } = renderHook(useNestedHook, {
-          initialProps: { impulse, spy: spyNested },
-        })
-
-        return {
-          first,
-          second,
-          third,
-          impulse,
-          spySingle,
-          spyNested,
-          resultSingle,
-          resultNested,
-        }
+      return {
+        first,
+        second,
+        third,
+        impulse,
+        spySingle,
+        spyNested,
+        resultSingle,
+        resultNested,
       }
+    }
 
-      it("calls watchers the same amount when initiates", () => {
-        const { spySingle, spyNested, resultSingle, resultNested } = setup()
+    it("calls watchers the same amount when initiates", () => {
+      const { spySingle, spyNested, resultSingle, resultNested } = setup()
 
-        expect(resultSingle.current).toStrictEqual({ count: 1 })
-        expect(resultNested.current).toStrictEqual({ count: 6 })
-        expect(spyNested).toHaveBeenCalledTimes(spySingle.mock.calls.length)
-      })
-
-      it("calls watchers the same amount when only first and second", () => {
-        const {
-          first,
-          second,
-          spySingle,
-          spyNested,
-          resultSingle,
-          resultNested,
-        } = setup()
-
-        act(() => {
-          batch(() => {
-            first.setValue(Counter.inc)
-            second.setValue(Counter.inc)
-          })
-        })
-        expect(resultSingle.current).toStrictEqual({ count: 2 })
-        expect(resultNested.current).toStrictEqual({ count: 8 })
-        expect(spyNested).toHaveBeenCalledTimes(spySingle.mock.calls.length)
-      })
-
-      it("calls watchers the same amount when only first and third", () => {
-        const {
-          first,
-          third,
-          spySingle,
-          spyNested,
-          resultSingle,
-          resultNested,
-        } = setup()
-
-        act(() => {
-          batch(() => {
-            first.setValue(Counter.inc)
-            third.setValue(Counter.inc)
-          })
-        })
-        expect(resultSingle.current).toStrictEqual({ count: 2 })
-        expect(resultNested.current).toStrictEqual({ count: 8 })
-        expect(spyNested).toHaveBeenCalledTimes(spySingle.mock.calls.length)
-      })
-
-      it("calls watchers the same amount when first, second and third", () => {
-        const {
-          first,
-          second,
-          third,
-          spySingle,
-          spyNested,
-          resultSingle,
-          resultNested,
-        } = setup()
-
-        act(() => {
-          batch(() => {
-            batch(() => {
-              first.setValue(Counter.inc)
-              second.setValue(Counter.inc)
-            })
-
-            third.setValue(Counter.inc)
-          })
-        })
-        expect(resultSingle.current).toStrictEqual({ count: 2 })
-        expect(resultNested.current).toStrictEqual({ count: 9 })
-        expect(spyNested).toHaveBeenCalledTimes(spySingle.mock.calls.length)
-      })
-
-      it("doesn't call single watcher when changes only second and third", () => {
-        const {
-          second,
-          third,
-          spySingle,
-          spyNested,
-          resultSingle,
-          resultNested,
-        } = setup()
-
-        spySingle.mockReset()
-        spyNested.mockReset()
-
-        act(() => {
-          batch(() => {
-            second.setValue(Counter.inc)
-            third.setValue(Counter.inc)
-          })
-        })
-        expect(resultSingle.current).toStrictEqual({ count: 1 })
-        expect(resultNested.current).toStrictEqual({ count: 8 })
-        expect(spySingle).not.toHaveBeenCalled()
-        expect(spyNested).toHaveBeenCalled()
-      })
-
-      it("Impulse#setValue wraps the callback into batch", () => {
-        const { second, third, impulse, spyNested, resultNested } = setup()
-
-        spyNested.mockReset()
-
-        act(() => {
-          batch(() => {
-            second.setValue(Counter.inc)
-            third.setValue(Counter.inc)
-          })
-        })
-
-        const spyCallsForBatch = spyNested.mock.calls.length
-
-        spyNested.mockReset()
-
-        act(() => {
-          impulse.setValue((current) => {
-            current.second.setValue(Counter.inc)
-            current.third.setValue(Counter.inc)
-
-            return current
-          })
-        })
-
-        expect(spyNested).toHaveBeenCalledTimes(spyCallsForBatch)
-        expect(resultNested.current).toStrictEqual({ count: 10 })
-      })
+      expect(resultSingle.current).toStrictEqual({ count: 1 })
+      expect(resultNested.current).toStrictEqual({ count: 6 })
+      expect(spyNested).toHaveBeenCalledTimes(spySingle.mock.calls.length)
     })
-  },
-)
+
+    it("calls watchers the same amount when only first and second", () => {
+      const {
+        first,
+        second,
+        spySingle,
+        spyNested,
+        resultSingle,
+        resultNested,
+      } = setup()
+
+      act(() => {
+        batch(() => {
+          first.setValue(Counter.inc)
+          second.setValue(Counter.inc)
+        })
+      })
+      expect(resultSingle.current).toStrictEqual({ count: 2 })
+      expect(resultNested.current).toStrictEqual({ count: 8 })
+      expect(spyNested).toHaveBeenCalledTimes(spySingle.mock.calls.length)
+    })
+
+    it("calls watchers the same amount when only first and third", () => {
+      const { first, third, spySingle, spyNested, resultSingle, resultNested } =
+        setup()
+
+      act(() => {
+        batch(() => {
+          first.setValue(Counter.inc)
+          third.setValue(Counter.inc)
+        })
+      })
+      expect(resultSingle.current).toStrictEqual({ count: 2 })
+      expect(resultNested.current).toStrictEqual({ count: 8 })
+      expect(spyNested).toHaveBeenCalledTimes(spySingle.mock.calls.length)
+    })
+
+    it("calls watchers the same amount when first, second and third", () => {
+      const {
+        first,
+        second,
+        third,
+        spySingle,
+        spyNested,
+        resultSingle,
+        resultNested,
+      } = setup()
+
+      act(() => {
+        batch(() => {
+          batch(() => {
+            first.setValue(Counter.inc)
+            second.setValue(Counter.inc)
+          })
+
+          third.setValue(Counter.inc)
+        })
+      })
+      expect(resultSingle.current).toStrictEqual({ count: 2 })
+      expect(resultNested.current).toStrictEqual({ count: 9 })
+      expect(spyNested).toHaveBeenCalledTimes(spySingle.mock.calls.length)
+    })
+
+    it("doesn't call single watcher when changes only second and third", () => {
+      const {
+        second,
+        third,
+        spySingle,
+        spyNested,
+        resultSingle,
+        resultNested,
+      } = setup()
+
+      spySingle.mockReset()
+      spyNested.mockReset()
+
+      act(() => {
+        batch(() => {
+          second.setValue(Counter.inc)
+          third.setValue(Counter.inc)
+        })
+      })
+      expect(resultSingle.current).toStrictEqual({ count: 1 })
+      expect(resultNested.current).toStrictEqual({ count: 8 })
+      expect(spySingle).not.toHaveBeenCalled()
+      expect(spyNested).toHaveBeenCalled()
+    })
+
+    it("Impulse#setValue wraps the callback into batch", () => {
+      const { second, third, impulse, spyNested, resultNested } = setup()
+
+      spyNested.mockReset()
+
+      act(() => {
+        batch(() => {
+          second.setValue(Counter.inc)
+          third.setValue(Counter.inc)
+        })
+      })
+
+      const spyCallsForBatch = spyNested.mock.calls.length
+
+      spyNested.mockReset()
+
+      act(() => {
+        impulse.setValue((current) => {
+          current.second.setValue(Counter.inc)
+          current.third.setValue(Counter.inc)
+
+          return current
+        })
+      })
+
+      expect(spyNested).toHaveBeenCalledTimes(spyCallsForBatch)
+      expect(resultNested.current).toStrictEqual({ count: 10 })
+    })
+  })
+})


### PR DESCRIPTION

Introduce dependencies optional argument for `useWatchImpulse`:

```dart
function useWatchImpulse<T>(
  watcher: () => T,
  dependencies?: DependencyList,
  options?: UseWatchImpulseOptions<T>
): T
```

It works the same way as `useEffect` dependencies argument - if the dependencies are not defined, the `watcher` will be called on every render. Otherwise, it will be called only when the dependencies change.

```ts
const impulse = useImpulse(0)

// before
const count = useWatchImpulse(
  useCallback(() => {
    return impulse.getValue()
  }, [impulse]),
)

// now
const count = useWatchImpulse(() => {
  return impulse.getValue()
}, [impulse])
```
