### PR TITLE
Introduce `untrack` function

### DIFF
--- a/.changeset/perfect-badgers-happen.md
+++ b/.changeset/perfect-badgers-happen.md
@@ -1,0 +1,12 @@
+---
+"react-impulse": major
+---
+
+Introduce the `untrack` function.
+
+```dart
+function untrack<TResult>(factory: (scope: Scope) => TResult): TResult
+function untrack<TValue>(impulse: Impulse<TValue>): TValue
+```
+
+The `untrack` function is a helper to read Impulses' values without reactivity. It provides a [`Scope`][scope] to the `factory` function and returns the result of the function. Acts as [`batch`][batch].

--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ const cloneOfMutable = mutable.clone((current) => ({
 - [`useScoped`][use_scoped] hook provides the `scope` argument. It can be used in custom hooks or inside components to narrow down the re-rendering scope.
 - [`subscribe`][subscribe] function provides the `scope` argument. It is useful outside of the React world.
 - [`batch`][batch] function provides the `scope` argument. Use it to optimize multiple Impulses updates or to access the Impulses' values inside async operations.
+- [`untrack`][untrack] function provides the `scope` argument. Use it when you need to read Impulses' values without reactivity.
 - [`useScopedCallback`][use_scoped_callback], [`useScopedMemo`][use_scoped_memo], [`useScopedEffect`][use_scoped_effect], [`useScopedLayoutEffect`][use_scoped_layout_effect] hooks provide the `scope` argument. They are enchanted versions of the React hooks that provide the `scope` argument as the first argument.
 
 ### `scoped`
@@ -719,6 +720,15 @@ const SumOfTwo: React.FC<{
 
 Alias for [`batch`][batch].
 
+### `untrack`
+
+```dart
+function untrack<TResult>(factory: (scope: Scope) => TResult): TResult
+function untrack<TValue>(impulse: Impulse<TValue>): TValue
+```
+
+The `untrack` function is a helper to read Impulses' values without reactivity. It provides a [`Scope`][scope] to the `factory` function and returns the result of the function. Acts as [`batch`][batch].
+
 ### `subscribe`
 
 ```dart
@@ -896,6 +906,7 @@ ESLint can also help validate unnecessary and abusive hooks/HOCs usage:
 [scope]: #scope
 [scoped]: #scoped
 [batch]: #batch
+[untrack]: #untrack
 [subscribe]: #subscribe
 [impulse_options]: #interface-impulseoptions
 [transmitting_impulse_options]: #interface-transmittingimpulseoptions

--- a/src/Impulse.ts
+++ b/src/Impulse.ts
@@ -145,8 +145,10 @@ export abstract class Impulse<T> {
   }
 
   protected _emit(execute: () => boolean): void {
-    ScopeEmitter._schedule(() => {
-      return execute() ? this._emitters : null
+    ScopeEmitter._schedule((queue) => {
+      if (execute()) {
+        queue.push(this._emitters)
+      }
     })
   }
 

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -11,7 +11,5 @@ import { ScopeEmitter } from "./ScopeEmitter"
 export function batch(execute: (scope: Scope) => void): void {
   ScopeEmitter._schedule(() => {
     execute(STATIC_SCOPE)
-
-    return null
   })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export {
   type ForwardedPropsWithoutScope,
   scoped,
 } from "./scoped"
+export { untrack } from "./untrack"
 export { batch } from "./batch"
 export { batch as tap } from "./batch"
 export { subscribe } from "./subscribe"

--- a/src/untrack.ts
+++ b/src/untrack.ts
@@ -1,0 +1,16 @@
+import { STATIC_SCOPE, type Scope } from "./Scope"
+import { ScopeEmitter } from "./ScopeEmitter"
+
+/**
+ * Ignores tracking any of the impulses attached to the provided Scope.
+ * Acts like `batch` but returns the `factory` function result.
+ *
+ * @param factory a function that provides `Scope` as the first argument and returns a result.
+ *
+ * @returns the `factory` function result.
+ *
+ * @version 1.0.0
+ */
+export function untrack<TResult>(factory: (scope: Scope) => TResult): TResult {
+  return ScopeEmitter._schedule(() => factory(STATIC_SCOPE))
+}

--- a/src/untrack.ts
+++ b/src/untrack.ts
@@ -1,5 +1,7 @@
+import type { Impulse } from "./Impulse"
 import { STATIC_SCOPE, type Scope } from "./Scope"
 import { ScopeEmitter } from "./ScopeEmitter"
+import { type Func, isFunction } from "./utils"
 
 /**
  * Ignores tracking any of the impulses attached to the provided Scope.
@@ -9,8 +11,27 @@ import { ScopeEmitter } from "./ScopeEmitter"
  *
  * @returns the `factory` function result.
  *
- * @version 1.0.0
+ * @version 2.0.0
  */
-export function untrack<TResult>(factory: (scope: Scope) => TResult): TResult {
-  return ScopeEmitter._schedule(() => factory(STATIC_SCOPE))
+export function untrack<TResult>(factory: (scope: Scope) => TResult): TResult
+
+/**
+ * Extracts the value from the provided `impulse` without tracking it.
+ *
+ * @param impulse an `Impulse` instance.
+ *
+ * @returns the `impulse` value.
+ *
+ * @version 2.0.0
+ */
+export function untrack<TValue>(impulse: Impulse<TValue>): TValue
+
+export function untrack<T>(factoryOrImpulse: Impulse<T> | Func<[Scope], T>): T {
+  return ScopeEmitter._schedule(() => {
+    if (isFunction(factoryOrImpulse)) {
+      return factoryOrImpulse(STATIC_SCOPE)
+    }
+
+    return factoryOrImpulse.getValue(STATIC_SCOPE)
+  })
 }

--- a/tests/hooks-in-components/untrack.spec.tsx
+++ b/tests/hooks-in-components/untrack.spec.tsx
@@ -1,0 +1,51 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+
+import { Impulse, untrack } from "../../src"
+
+it("returns the `factory` function untracked result", () => {
+  const onRender = vi.fn()
+  const counter = Impulse.of({ count: 0 })
+
+  const Component: React.FC<{
+    multiplier: number
+  }> = ({ multiplier }) => {
+    const { count } = untrack((scope) => counter.getValue(scope))
+    const [, rerender] = React.useState(0)
+
+    return (
+      <button type="button" onClick={() => rerender((x) => x + 1)}>
+        {multiplier * count}
+      </button>
+    )
+  }
+
+  const { rerender } = render(<Component multiplier={1} />, {
+    wrapper: (props) => (
+      <React.Profiler id="test" onRender={onRender} {...props} />
+    ),
+  })
+
+  expect(screen.getByRole("button")).toHaveTextContent("0")
+  expect(onRender).toHaveBeenCalledTimes(1)
+  vi.clearAllMocks()
+
+  counter.setValue({ count: 1 })
+  expect(screen.getByRole("button")).toHaveTextContent("0")
+  expect(onRender).toHaveBeenCalledTimes(0)
+  vi.clearAllMocks()
+
+  rerender(<Component multiplier={2} />)
+  expect(screen.getByRole("button")).toHaveTextContent("2")
+  expect(onRender).toHaveBeenCalledTimes(1)
+  vi.clearAllMocks()
+
+  counter.setValue({ count: 2 })
+  expect(screen.getByRole("button")).toHaveTextContent("2")
+  expect(onRender).toHaveBeenCalledTimes(0)
+  vi.clearAllMocks()
+
+  fireEvent.click(screen.getByRole("button"))
+  expect(screen.getByRole("button")).toHaveTextContent("4")
+  expect(onRender).toHaveBeenCalledTimes(1)
+})

--- a/tests/hooks-in-components/untrack.spec.tsx
+++ b/tests/hooks-in-components/untrack.spec.tsx
@@ -3,19 +3,21 @@ import { fireEvent, render, screen } from "@testing-library/react"
 
 import { Impulse, untrack } from "../../src"
 
-it("returns the `factory` function untracked result", () => {
+it("returns the `factory` function result without tracking impulses", () => {
   const onRender = vi.fn()
-  const counter = Impulse.of({ count: 0 })
+  const first = Impulse.of({ count: 1 })
+  const second = Impulse.of({ count: 2 })
 
   const Component: React.FC<{
     multiplier: number
   }> = ({ multiplier }) => {
-    const { count } = untrack((scope) => counter.getValue(scope))
+    const { count: firstCount } = untrack((scope) => first.getValue(scope))
+    const { count: secondCount } = untrack(second)
     const [, rerender] = React.useState(0)
 
     return (
       <button type="button" onClick={() => rerender((x) => x + 1)}>
-        {multiplier * count}
+        {multiplier * (firstCount + secondCount)}
       </button>
     )
   }
@@ -26,26 +28,28 @@ it("returns the `factory` function untracked result", () => {
     ),
   })
 
-  expect(screen.getByRole("button")).toHaveTextContent("0")
+  expect(screen.getByRole("button")).toHaveTextContent("3")
   expect(onRender).toHaveBeenCalledTimes(1)
   vi.clearAllMocks()
 
-  counter.setValue({ count: 1 })
-  expect(screen.getByRole("button")).toHaveTextContent("0")
+  first.setValue({ count: 2 })
+  second.setValue({ count: 3 })
+  expect(screen.getByRole("button")).toHaveTextContent("3")
   expect(onRender).toHaveBeenCalledTimes(0)
   vi.clearAllMocks()
 
   rerender(<Component multiplier={2} />)
-  expect(screen.getByRole("button")).toHaveTextContent("2")
+  expect(screen.getByRole("button")).toHaveTextContent("10")
   expect(onRender).toHaveBeenCalledTimes(1)
   vi.clearAllMocks()
 
-  counter.setValue({ count: 2 })
-  expect(screen.getByRole("button")).toHaveTextContent("2")
+  first.setValue({ count: 3 })
+  second.setValue({ count: 4 })
+  expect(screen.getByRole("button")).toHaveTextContent("10")
   expect(onRender).toHaveBeenCalledTimes(0)
   vi.clearAllMocks()
 
   fireEvent.click(screen.getByRole("button"))
-  expect(screen.getByRole("button")).toHaveTextContent("4")
+  expect(screen.getByRole("button")).toHaveTextContent("14")
   expect(onRender).toHaveBeenCalledTimes(1)
 })


### PR DESCRIPTION
Resolves #577 

In addition to the [solidjs](https://www.solidjs.com/docs/latest/api#untrack) version, the `untrack` function has a shortcut for Impulse:

```dart
function untrack<TResult>(factory: (scope: Scope) => TResult): TResult
function untrack<TValue>(impulse: Impulse<TValue>): TValue
```