### PR TITLE
Set `singleThread: true`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,11 @@ import { defineConfig } from "vitest/config"
 export default defineConfig({
   test: {
     globals: true,
+    poolOptions: {
+      threads: {
+        singleThread: true,
+      },
+    },
     // https://github.com/vitest-dev/vitest/issues/3967#issuecomment-1680585071
     testTransformMode: {
       ssr: ["**/*"],


### PR DESCRIPTION
Runs all tests in a single thread without isolation. The tests run time drop >3 times (locally)