### PR TITLE
Await the check for lazy

### DIFF
--- a/tests/hooks-in-components/scoped.spec.tsx
+++ b/tests/hooks-in-components/scoped.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, act } from "@testing-library/react"
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react"
 import React, { type ForwardRefRenderFunction } from "react"
 
 import {
@@ -658,7 +658,7 @@ describe("scoped.forwardRef()", () => {
 
     const LazyComponent = React.lazy<typeof Component>(() => {
       return new Promise((done) => {
-        setTimeout(() => done({ default: Component }), 100)
+        setTimeout(() => done({ default: Component }), 10)
       })
     })
     const count = Impulse.of(0)
@@ -676,7 +676,10 @@ describe("scoped.forwardRef()", () => {
     act(() => {
       count.setValue((x) => x + 1)
     })
-    expect(screen.getByTestId("count")).toHaveTextContent("1")
+
+    await waitFor(() => {
+      expect(screen.getByTestId("count")).toHaveTextContent("1")
+    })
   })
 
   it("forwards correct props", () => {


### PR DESCRIPTION
Some jobs ([one](https://github.com/owanturist/react-impulse/actions/runs/7308041156/job/19914302168?pr=593)) fail due to the failed check.