### PR TITLE
Fix runtime error caused by `useStable` for compare in `useTransmittingImpulse`

### DIFF
--- a/.changeset/tiny-hats-draw.md
+++ b/.changeset/tiny-hats-draw.md
@@ -1,0 +1,5 @@
+---
+"react-impulse": patch
+---
+
+Assign a compare function to a stable ref during the initial render so that Impulses created via `useImpulse` and `useTransmittingImpulse` can use `getValue()` and `setValue()` during initial render. Resolves #624.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![known vulnerabilities](https://snyk.io/test/github/owanturist/react-impulse/badge.svg)
 ![types](https://badgen.net/npm/types/react-impulse)
 [![npm version](https://badge.fury.io/js/react-impulse.svg)](https://badge.fury.io/js/react-impulse)
+[![view changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/react-impulse)
 
 The clean and natural React state management.
 

--- a/src/useImpulse.ts
+++ b/src/useImpulse.ts
@@ -1,12 +1,6 @@
 import { Impulse, type ImpulseOptions } from "./Impulse"
 import { STATIC_SCOPE, type Scope } from "./Scope"
-import {
-  isFunction,
-  usePermanent,
-  useStableCallback,
-  eq,
-  type Func,
-} from "./utils"
+import { isFunction, usePermanent, useHandler, eq, type Func } from "./utils"
 
 /**
  * A hook that initiates a stable (never changing) Impulse without an initial value.
@@ -35,7 +29,7 @@ export function useImpulse<T>(
   valueOrInitValue?: T | Func<[Scope], T>,
   options?: ImpulseOptions<undefined | T>,
 ): Impulse<undefined | T> {
-  const stableCompare = useStableCallback(
+  const stableCompare = useHandler(
     (prev: undefined | T, next: undefined | T, scope: Scope) => {
       const compare = options?.compare ?? eq
 

--- a/src/useScoped.ts
+++ b/src/useScoped.ts
@@ -1,11 +1,5 @@
 import { type DependencyList, useCallback, useDebugValue } from "./dependencies"
-import {
-  type Compare,
-  eq,
-  useStableCallback,
-  type Func,
-  isFunction,
-} from "./utils"
+import { type Compare, eq, useHandler, type Func, isFunction } from "./utils"
 import { STATIC_SCOPE, type Scope } from "./Scope"
 import { useScope } from "./useScope"
 import type { ReadonlyImpulse } from "./Impulse"
@@ -65,7 +59,7 @@ export function useScoped<TResult>(
   )
   const value = useScope(
     transform,
-    useStableCallback((prev, next) => {
+    useHandler((prev, next) => {
       const compare = options?.compare ?? eq
 
       return compare(prev, next, STATIC_SCOPE)

--- a/src/useTransmittingImpulse.ts
+++ b/src/useTransmittingImpulse.ts
@@ -10,7 +10,7 @@ import type { Scope } from "./Scope"
 import {
   noop,
   eq,
-  useStableCallback,
+  useHandler,
   usePermanent,
   useIsomorphicLayoutEffect,
   isFunction,
@@ -67,10 +67,10 @@ export function useTransmittingImpulse<T>(
       ? [setterOrOptions, maybeOptions]
       : [noop, setterOrOptions]
 
-  const stableSetter = useStableCallback(
+  const stableSetter = useHandler(
     isFunction(setter) ? setter : (value: T) => setter.setValue(value),
   )
-  const stableCompare = useStableCallback((prev: T, next: T, scope: Scope) => {
+  const stableCompare = useHandler((prev: T, next: T, scope: Scope) => {
     const compare = options?.compare ?? eq
 
     return compare(prev, next, scope)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,6 @@ import {
   useEffect,
   useLayoutEffect,
   useRef,
-  useCallback,
   useState,
 } from "./dependencies"
 
@@ -39,17 +38,19 @@ export const useIsomorphicLayoutEffect =
   /* c8 ignore next */
   typeof window === "undefined" ? useEffect : useLayoutEffect
 
-export function useStableCallback<
-  TArgs extends ReadonlyArray<unknown>,
-  TResult,
->(handler: Func<TArgs, TResult>): Func<TArgs, TResult> {
-  const handlerRef = useRef<Func<TArgs, TResult>>(null as never)
+export function useHandler<TArgs extends ReadonlyArray<unknown>, TResult>(
+  handler: Func<TArgs, TResult>,
+): Func<TArgs, TResult> {
+  const handlerRef = useRef(handler)
+  const stableRef = useRef(
+    (...args: TArgs): TResult => handlerRef.current(...args),
+  )
 
   useIsomorphicLayoutEffect(() => {
     handlerRef.current = handler
   })
 
-  return useCallback((...args) => handlerRef.current(...args), [])
+  return stableRef.current
 }
 
 export function usePermanent<TValue>(init: () => TValue): TValue {

--- a/tests/useTransmittingImpulse.spec.ts
+++ b/tests/useTransmittingImpulse.spec.ts
@@ -638,15 +638,3 @@ describe("type check", () => {
     expectTypeOf(result.current).toEqualTypeOf<Impulse<number>>()
   })
 })
-
-it("x", ({ scope }) => {
-  const { result } = renderHook(() => {
-    const y = useImpulse(0)
-
-    return useTransmittingImpulse((scope) => y.getValue(scope), [y])
-  })
-
-  expect(result.current.getValue(scope)).toBe(0)
-  expect(result.current.getValue(scope)).toBe(0)
-  expect(result.current.getValue(scope)).toBe(0)
-})

--- a/tests/useTransmittingImpulse.spec.ts
+++ b/tests/useTransmittingImpulse.spec.ts
@@ -638,3 +638,15 @@ describe("type check", () => {
     expectTypeOf(result.current).toEqualTypeOf<Impulse<number>>()
   })
 })
+
+it("x", ({ scope }) => {
+  const { result } = renderHook(() => {
+    const y = useImpulse(0)
+
+    return useTransmittingImpulse((scope) => y.getValue(scope), [y])
+  })
+
+  expect(result.current.getValue(scope)).toBe(0)
+  expect(result.current.getValue(scope)).toBe(0)
+  expect(result.current.getValue(scope)).toBe(0)
+})


### PR DESCRIPTION
Assign a compare function to a stable ref during the initial render so that Impulses created via `useImpulse` and `useTransmittingImpulse` can use `getValue()` and `setValue()` during initial render. Resolves #624.