### PR TITLE
Always emit changes for `TransmittingImpulse#setValue`

### DIFF
--- a/.changeset/tame-tables-push.md
+++ b/.changeset/tame-tables-push.md
@@ -1,0 +1,5 @@
+---
+"react-impulse": patch
+---
+
+The `TransmittingImpulse#setValue` method always emits changes to enforce the transmitting value update for cases when the value is not reactive (ex. `localStorage`, global values, etc). Resolves #627.

--- a/src/Impulse.ts
+++ b/src/Impulse.ts
@@ -334,9 +334,9 @@ export class TransmittingImpulse<T> extends Impulse<T> {
   protected _setter(value: T): boolean {
     this._setValue(value, STATIC_SCOPE)
 
-    // the TransmittingImpulse does not need to emit changes by itself
-    // the transmitted impulses do it instead
-    return false
+    // should always emit because the transmitting value might be not reactive
+    // so the _getter method does not know about the change of such values
+    return true
   }
 
   public _replaceGetter(getter: (scope: Scope) => T): void {

--- a/tests/Impulse.spec.ts
+++ b/tests/Impulse.spec.ts
@@ -374,7 +374,7 @@ describe("Impulse.transmit(getter, setter, options?)", () => {
     })
 
     expect(result.current).toBe(12)
-    expect(spy).not.toHaveBeenCalled()
+    expect(spy).toHaveBeenCalledOnce()
   })
 })
 

--- a/tests/bugfixes.spec.tsx
+++ b/tests/bugfixes.spec.tsx
@@ -296,3 +296,58 @@ describe("useTransmittingImpulse stable compare throws an error #624", () => {
     })
   })
 })
+
+describe("TransmittingImpulse.setValue does not enqueue a rerender when sets a not reactive value #627", () => {
+  describe("Impulse.transmit()", () => {
+    it("enqueues a rerender when sets a reactive value", () => {
+      const counter = { count: 0 }
+      const impulse = Impulse.transmit(
+        () => counter.count,
+        (count) => {
+          counter.count = count
+        },
+      )
+
+      const { result } = renderHook(() => {
+        return useScoped(impulse)
+      })
+
+      expect(result.current).toBe(0)
+
+      act(() => {
+        impulse.setValue(1)
+      })
+
+      expect(result.current).toBe(1)
+    })
+  })
+
+  describe("useTransmittingImpulse()", () => {
+    it("enqueues a rerender when sets a reactive value", () => {
+      const counter = { count: 0 }
+
+      const { result } = renderHook(() => {
+        const impulse = useTransmittingImpulse(
+          () => counter.count,
+          [],
+          (count) => {
+            counter.count = count
+          },
+        )
+
+        return {
+          impulse,
+          value: useScoped(impulse),
+        }
+      })
+
+      expect(result.current.value).toBe(0)
+
+      act(() => {
+        result.current.impulse.setValue(1)
+      })
+
+      expect(result.current.value).toBe(1)
+    })
+  })
+})

--- a/tests/useTransmittingImpulse.spec.ts
+++ b/tests/useTransmittingImpulse.spec.ts
@@ -10,6 +10,7 @@ import {
   useScopedEffect,
   type ReadonlyImpulse,
   type Scope,
+  useScoped,
 } from "../src"
 
 import type { Counter } from "./common"
@@ -28,6 +29,7 @@ function setupWithGlobal() {
 
     return {
       impulse,
+      value: useScoped(impulse),
       getCount: () => counter.count,
       setCount: (x: number) => {
         counter = { count: x }
@@ -53,6 +55,7 @@ function setupWithReactState() {
 
     return {
       impulse,
+      value: useScoped(impulse),
       getCount: () => count,
       setCount: (x: number) => setCounter({ count: x }),
     }
@@ -76,6 +79,7 @@ function setupWithImpulse() {
 
     return {
       impulse,
+      value: useScoped(impulse),
       getCount: (scope: Scope) => counter.getValue(scope).count,
       setCount: (x: number) => counter.setValue({ count: x }),
     }
@@ -97,6 +101,7 @@ function setupWithImpulseGetterShortcut() {
 
     return {
       impulse,
+      value: useScoped(impulse),
       getCount: (scope: Scope) => counter.getValue(scope),
       setCount: (x: number) => counter.setValue(x),
     }
@@ -120,6 +125,7 @@ function setupWithImpulseSetterShortcut() {
 
     return {
       impulse,
+      value: useScoped(impulse),
       getCount: (scope: Scope) => counter.getValue(scope),
       setCount: (x: number) => counter.setValue(x),
     }
@@ -139,6 +145,7 @@ function setupWithImpulseGetterAndSetterShortcuts() {
 
     return {
       impulse,
+      value: useScoped(impulse),
       getCount: (scope: Scope) => counter.getValue(scope),
       setCount: (x: number) => counter.setValue(x),
     }
@@ -200,7 +207,15 @@ describe.each([
     act(() => {
       result.current.setCount(1)
     })
+    // the global value updates on its own without causing a re-render
+    expect([1, 0]).toContain(result.current.value)
     expect(result.current.impulse.getValue(scope)).toBe(1)
+
+    act(() => {
+      result.current.impulse.setValue(2)
+    })
+    expect(result.current.value).toBe(2)
+    expect(result.current.getCount(scope)).toBe(2)
   })
 
   it("update the origin value when the Impulse value changes", ({ scope }) => {


### PR DESCRIPTION
The `TransmittingImpulse#setValue` method always emits changes to enforce the transmitting value update for cases when the value is not reactive (ex. `localStorage`, global values, etc). Resolves #627.
