### PR TITLE
Fix `use-sync-external-store/shim/with-selector` import

### DIFF
--- a/.changeset/plenty-houses-decide.md
+++ b/.changeset/plenty-houses-decide.md
@@ -1,0 +1,5 @@
+---
+"react-impulse": patch
+---
+
+Change import `use-sync-external-store/shim/with-selector` to `use-sync-external-store/shim/with-selector.js`.

--- a/packages/react-impulse/src/dependencies.ts
+++ b/packages/react-impulse/src/dependencies.ts
@@ -23,4 +23,4 @@ export {
   useLayoutEffect,
   useDebugValue,
 } from "react"
-export { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/with-selector"
+export { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/with-selector.js"


### PR DESCRIPTION
Fixes the following build time error


>Cannot find module '/Users/aovechkin/Projects/stackstate/stackstate-ui/node_modules/use-sync-external-store/shim/with-selector' imported from /Users/aovechkin/Projects/stackstate/stackstate-ui/node_modules/react-impulse/dist/index.js
>
> Did you mean to import use-sync-external-store/shim/with-selector.js?
