### PR TITLE
Include `pnpm-lock.yaml` as dependency for `lint` and `format`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,13 @@ jobs:
             eslintrc:
               - .eslintrc.json
               - .eslintignore
+              - pnpm-lock.yaml
             eslint_target:
               - "**/*.{ts,tsx,js,jsx}"
             prettierrc:
               - .prettierrc
               - .prettierignore
+              - pnpm-lock.yaml
             prettier_target:
               - "**/*.*"
 

--- a/packages/react-impulse-form/tsconfig.json
+++ b/packages/react-impulse-form/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src", "tests", "./*.ts"]
+  "include": ["src", "tests", "./*.ts"],
 }

--- a/packages/react-impulse/tsconfig.json
+++ b/packages/react-impulse/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src", "tests", "./*.ts"]
+  "include": ["src", "tests", "./*.ts"],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "noUncheckedIndexedAccess": true,
     "downlevelIteration": true,
     "jsx": "react",
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
   },
-  "include": ["./*.ts"]
+  "include": ["./*.ts"],
 }


### PR DESCRIPTION
The changes make sure that the `lint` and `format` scripts run for entire codebase if `pnpm-lock` has changed.