### PR TITLE
Rename `ImpulseFormValueOptions.compare` to `isOriginalValueEqual`

### DIFF
--- a/.changeset/nervous-cougars-remember.md
+++ b/.changeset/nervous-cougars-remember.md
@@ -1,0 +1,8 @@
+---
+"react-impulse-form": minor
+---
+
+Breaking change:
+
+- Rename `ImpulseFormValueOptions.compare` to `ImpulseFormValueOptions.isOriginalValueEqual`
+- `ImpulseFormValue#setOriginalValue` does not reset errors on call anymore. Call `ImpulseFormValue#setErrors([])` manually when needed.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 Below are links to the various packages in this monorepo:
 
 - [`react-impulse`](./packages/react-impulse/README.md)
+- [`react-impulse-form`](./packages/react-impulse-form/README.md)

--- a/packages/react-impulse-form/CHANGELOG.md
+++ b/packages/react-impulse-form/CHANGELOG.md
@@ -59,7 +59,7 @@
     +ImpulseFormValue#setSchema(schema: Schema | null): void
     ```
 
-  Change:
+  Breaking change:
 
   - use `ImpulseForm#submit`, `ImpulseForm#getSubmitCount`, `ImpulseForm#isSubmitting` instead
 

--- a/packages/react-impulse-form/src/ImpulseFormValue.ts
+++ b/packages/react-impulse-form/src/ImpulseFormValue.ts
@@ -119,7 +119,7 @@ export class ImpulseFormValue<
     }: ImpulseFormValueOptions<TOriginalValue, TValue> = {},
   ): ImpulseFormValue<TOriginalValue, TValue> {
     const isOriginalValueEqualImpulse = Impulse.of(isOriginalValueEqual)
-    const isOriginalValueEqualFn: Compare<TOriginalValue> = (
+    const isOriginalValueEqualStable: Compare<TOriginalValue> = (
       left,
       right,
       scope,
@@ -129,13 +129,21 @@ export class ImpulseFormValue<
       return compare(left, right, scope)
     }
 
+    const initialOriginalValue = untrack((scope) => {
+      if (isOriginalValueEqual(initialValue, originalValue, scope)) {
+        return initialValue
+      }
+
+      return originalValue
+    })
+
     return new ImpulseFormValue(
       null,
       Impulse.of(touched),
       Impulse.of(validateOn),
       Impulse.of(errors ?? [], { compare: shallowArrayEquals }),
-      Impulse.of(initialValue, { compare: isOriginalValueEqualFn }),
-      Impulse.of(originalValue, { compare: isOriginalValueEqualFn }),
+      Impulse.of(initialValue, { compare: isOriginalValueEqualStable }),
+      Impulse.of(initialOriginalValue, { compare: isOriginalValueEqualStable }),
       Impulse.of(schema),
       isOriginalValueEqualImpulse,
     )

--- a/packages/react-impulse-form/src/utils.ts
+++ b/packages/react-impulse-form/src/utils.ts
@@ -21,7 +21,7 @@ export const isHtmlElement = (value: unknown): value is HTMLElement => {
   return value instanceof HTMLElement
 }
 
-const eq = <T>(left: T, right: T): boolean => Object.is(left, right)
+export const eq = <T>(left: T, right: T): boolean => Object.is(left, right)
 
 export const uniq = <T>(values: ReadonlyArray<T>): ReadonlyArray<T> => {
   const acc = new Set<T>()
@@ -43,7 +43,7 @@ export function shallowArrayEquals<T>(
   left: ReadonlyArray<T>,
   right: ReadonlyArray<T>,
 ): boolean {
-  if (Object.is(left, right)) {
+  if (eq(left, right)) {
     return true
   }
 

--- a/packages/react-impulse-form/tests/ImpulseFormShape.test.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormShape.test.ts
@@ -1,6 +1,5 @@
 // TODO split all tests like ./ImpulseFormShape/isValidated.test.ts
 
-import { equals } from "remeda"
 import { z } from "zod"
 
 import {
@@ -1840,9 +1839,7 @@ describe("ImpulseFormShape#isDirty()", () => {
       second: ImpulseFormValue.of(0),
       third: ImpulseFormShape.of({
         one: ImpulseFormValue.of(true),
-        two: ImpulseFormValue.of([""], {
-          compare: (left, right) => equals(left, right),
-        }),
+        two: ImpulseFormValue.of([""]),
       }),
       fourth: ["anything"],
     })
@@ -1996,9 +1993,7 @@ describe("ImpulseFormShape#reset()", () => {
         second: ImpulseFormValue.of(0),
         third: ImpulseFormShape.of({
           one: ImpulseFormValue.of(true),
-          two: ImpulseFormValue.of([""], {
-            compare: (left, right) => equals(left, right),
-          }),
+          two: ImpulseFormValue.of([""]),
         }),
         fourth: ["anything"],
       },

--- a/packages/react-impulse-form/tests/ImpulseFormShape/focusFirstInvalidValue.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormShape/focusFirstInvalidValue.spec.ts
@@ -62,6 +62,15 @@ const setup = (
   ] as const
 }
 
+it("matches the type signature", () => {
+  const [form] = setup()
+
+  expectTypeOf(form.focusFirstInvalidValue).toEqualTypeOf<VoidFunction>()
+  expectTypeOf(
+    form.fields._3.focusFirstInvalidValue,
+  ).toEqualTypeOf<VoidFunction>()
+})
+
 describe("focusFirstInvalidValue()", () => {
   it("calls a single validated field's listener", () => {
     const [form, { listener_1, listener_2, listener_3_1, listener_3_2 }] =

--- a/packages/react-impulse-form/tests/ImpulseFormShape/getSubmitCount.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormShape/getSubmitCount.spec.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import type { Scope } from "react-impulse"
 
 import { ImpulseFormValue, ImpulseFormShape } from "../../src"
 import { wait } from "../common"
@@ -38,6 +39,16 @@ const setupShape =
 
 beforeAll(() => {
   vi.useFakeTimers()
+})
+
+it("matches the type signature", () => {
+  const form = setupShape()()
+
+  expectTypeOf(form.getSubmitCount).toEqualTypeOf<(scope: Scope) => number>()
+
+  expectTypeOf(form.fields._3.getSubmitCount).toEqualTypeOf<
+    (scope: Scope) => number
+  >()
 })
 
 describe.each([

--- a/packages/react-impulse-form/tests/ImpulseFormShape/isSubmitting.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormShape/isSubmitting.spec.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import type { Scope } from "react-impulse"
 
 import {
   type ImpulseFormShapeOptions,
@@ -46,6 +47,16 @@ const setupShape =
 
 beforeAll(() => {
   vi.useFakeTimers()
+})
+
+it("matches the type signature", () => {
+  const form = setupShape()()
+
+  expectTypeOf(form.isSubmitting).toEqualTypeOf<(scope: Scope) => boolean>()
+
+  expectTypeOf(form.fields._3.isSubmitting).toEqualTypeOf<
+    (scope: Scope) => boolean
+  >()
 })
 
 describe.each([

--- a/packages/react-impulse-form/tests/ImpulseFormShape/onSubmit.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormShape/onSubmit.spec.ts
@@ -19,6 +19,18 @@ type ShapeFields = {
   _4: Array<string>
 }
 
+type ThirdValueVerbose = {
+  readonly _1: boolean
+  readonly _2: Array<string>
+}
+
+type RootValueVerbose = {
+  readonly _1: string
+  readonly _2: number
+  readonly _3: ThirdValueVerbose
+  readonly _4: Array<string>
+}
+
 const setup = (options?: ImpulseFormShapeOptions<ShapeFields>) => {
   return ImpulseFormShape.of(
     {
@@ -42,6 +54,22 @@ beforeAll(() => {
   vi.useFakeTimers()
 })
 
+it("matches the type signature", () => {
+  const form = setup()
+
+  expectTypeOf(form.onSubmit).toEqualTypeOf<
+    (
+      listener: (value: RootValueVerbose) => void | Promise<unknown>,
+    ) => VoidFunction
+  >()
+
+  expectTypeOf(form.fields._3.onSubmit).toEqualTypeOf<
+    (
+      listener: (value: ThirdValueVerbose) => void | Promise<unknown>,
+    ) => VoidFunction
+  >()
+})
+
 describe.each<
   [string, (form: ImpulseFormShape<ShapeFields>) => Promise<unknown>]
 >([
@@ -57,15 +85,7 @@ describe.each<
     const form = setup()
 
     form.onSubmit((value) => {
-      expectTypeOf(value).toEqualTypeOf<{
-        readonly _1: string
-        readonly _2: number
-        readonly _3: {
-          readonly _1: boolean
-          readonly _2: Array<string>
-        }
-        readonly _4: Array<string>
-      }>()
+      expectTypeOf(value).toEqualTypeOf<RootValueVerbose>()
     })
   })
 

--- a/packages/react-impulse-form/tests/ImpulseFormShape/setValidateOn.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormShape/setValidateOn.spec.ts
@@ -31,48 +31,49 @@ const setup = (
   )
 }
 
+it("matches the type signature", () => {
+  const form = setup()
+
+  type ThirdValidateStrategy = {
+    readonly one: ValidateStrategy
+    readonly two: ValidateStrategy
+  }
+
+  type ThirdValidateOnSetter = Setter<
+    | ValidateStrategy
+    | {
+        readonly one?: Setter<ValidateStrategy>
+        readonly two?: Setter<ValidateStrategy>
+      },
+    [ThirdValidateStrategy]
+  >
+
+  type RootValidateOnSetter = Setter<
+    | ValidateStrategy
+    | {
+        readonly first?: Setter<ValidateStrategy>
+        readonly second?: Setter<ValidateStrategy>
+        readonly third?: ThirdValidateOnSetter
+      },
+    [
+      {
+        readonly first: ValidateStrategy
+        readonly second: ValidateStrategy
+        readonly third: ThirdValidateStrategy
+      },
+    ]
+  >
+
+  expectTypeOf(form.setValidateOn).toEqualTypeOf<
+    (setter: RootValidateOnSetter) => void
+  >()
+
+  expectTypeOf(form.fields.third.setValidateOn).toEqualTypeOf<
+    (setter: ThirdValidateOnSetter) => void
+  >()
+})
+
 describe("setValidateOn(..)", () => {
-  it("matches the type signature", () => {
-    const shape = setup()
-
-    type ThirdValidateStrategy = {
-      readonly one: ValidateStrategy
-      readonly two: ValidateStrategy
-    }
-
-    type ThirdValidateOnSetter = Setter<
-      | ValidateStrategy
-      | {
-          readonly one?: Setter<ValidateStrategy>
-          readonly two?: Setter<ValidateStrategy>
-        },
-      [ThirdValidateStrategy]
-    >
-
-    type RootValidateOnSetter = Setter<
-      | ValidateStrategy
-      | {
-          readonly first?: Setter<ValidateStrategy>
-          readonly second?: Setter<ValidateStrategy>
-          readonly third?: ThirdValidateOnSetter
-        },
-      [
-        {
-          readonly first: ValidateStrategy
-          readonly second: ValidateStrategy
-          readonly third: ThirdValidateStrategy
-        },
-      ]
-    >
-
-    expectTypeOf(shape.setValidateOn).toEqualTypeOf<
-      (setter: RootValidateOnSetter) => void
-    >()
-    expectTypeOf(shape.fields.third.setValidateOn).toEqualTypeOf<
-      (setter: ThirdValidateOnSetter) => void
-    >()
-  })
-
   it("sets the ValidateStrategy to ALL fields", ({ scope }) => {
     const shape = setup()
 

--- a/packages/react-impulse-form/tests/ImpulseFormValue.test.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormValue.test.ts
@@ -293,22 +293,6 @@ describe("ImpulseFormValue#setOriginalValue()", () => {
       .parameter(0)
       .toEqualTypeOf<Setter<string>>()
   })
-
-  it("resets error when originalValue changes", ({ scope }) => {
-    const value = ImpulseFormValue.of(
-      { foo: 1 },
-      {
-        compare: (left, right) => equals(left, right),
-      },
-    )
-
-    value.setErrors(["error"])
-    value.setOriginalValue({ foo: 1 })
-    expect(value.getErrors(scope)).toStrictEqual(["error"])
-
-    value.setOriginalValue({ foo: 2 })
-    expect(value.getErrors(scope)).toBeNull()
-  })
 })
 
 describe("ImpulseFormValue#setInitialValue()", () => {

--- a/packages/react-impulse-form/tests/ImpulseFormValue.test.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormValue.test.ts
@@ -352,7 +352,7 @@ describe("ImpulseFormValue#isDirty()", () => {
       { type: "zero", value: 0 },
       {
         initialValue: { type: "zero", value: 0 },
-        compare: (left, right) => equals(left, right),
+        isOriginalValueEqual: (left, right) => equals(left, right),
       },
     )
     expect(value.isDirty(scope)).toBe(false)

--- a/packages/react-impulse-form/tests/ImpulseFormValue.test.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormValue.test.ts
@@ -143,6 +143,42 @@ describe("ImpulseFormValue.of()", () => {
     expect(value.getOriginalValue(scope)).toBe("")
     expect(value.getInitialValue(scope)).toBe("1")
   })
+
+  it("returns initialValue if it is equals to originalValue with custom isOriginalValueEqual", ({
+    scope,
+  }) => {
+    const initialValue = { count: 0 }
+    const form = ImpulseFormValue.of(
+      { count: 0 },
+      {
+        initialValue,
+        isOriginalValueEqual: (left, right) => left.count === right.count,
+      },
+    )
+
+    expect(form.getOriginalValue(scope)).toBe(initialValue)
+    expect(form.getOriginalValue(scope)).toBe(form.getInitialValue(scope))
+
+    form.setOriginalValue({ count: 1 })
+    expect(form.getOriginalValue(scope)).not.toBe(initialValue)
+  })
+
+  it("keeps the prev value with custom isOriginalValueEqual", ({ scope }) => {
+    const form = ImpulseFormValue.of(
+      { count: 0 },
+      {
+        isOriginalValueEqual: (left, right) => left.count === right.count,
+      },
+    )
+
+    const originalValue = form.getOriginalValue(scope)
+
+    form.setOriginalValue({ count: 0 })
+    expect(form.getOriginalValue(scope)).toBe(originalValue)
+
+    form.setOriginalValue({ count: 1 })
+    expect(form.getOriginalValue(scope)).not.toBe(originalValue)
+  })
 })
 
 describe("ImpulseFormValue#getValue()", () => {

--- a/packages/react-impulse-form/tests/ImpulseFormValue/focusFirstInvalidValue.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormValue/focusFirstInvalidValue.spec.ts
@@ -13,6 +13,12 @@ const setup = (
   })
 }
 
+it("matches the type signature", () => {
+  const form = setup()
+
+  expectTypeOf(form.focusFirstInvalidValue).toEqualTypeOf<VoidFunction>()
+})
+
 describe("focusFirstInvalidValue() when validated", () => {
   it("nothing happens if a listener is not attached", () => {
     const form = setup()

--- a/packages/react-impulse-form/tests/ImpulseFormValue/getSubmitCount.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormValue/getSubmitCount.spec.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import type { Scope } from "react-impulse"
 
 import { ImpulseFormValue } from "../../src"
 import { wait } from "../common"
@@ -18,6 +19,12 @@ const setupValue =
 
 beforeAll(() => {
   vi.useFakeTimers()
+})
+
+it("matches the type signature", () => {
+  const form = setupValue()()
+
+  expectTypeOf(form.getSubmitCount).toEqualTypeOf<(scope: Scope) => number>()
 })
 
 describe.each([

--- a/packages/react-impulse-form/tests/ImpulseFormValue/getValidateOn.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormValue/getValidateOn.spec.ts
@@ -19,6 +19,18 @@ const getValidateOnConcise = (scope: Scope, value: ImpulseFormValue<string>) =>
 const getValidateOnVerbose = (scope: Scope, value: ImpulseFormValue<string>) =>
   value.getValidateOn(scope, (_, verbose) => verbose)
 
+it("matches the type signature", () => {
+  const form = setup()
+
+  expectTypeOf(form.getValidateOn).toEqualTypeOf<{
+    (scope: Scope): ValidateStrategy
+    <TResult>(
+      scope: Scope,
+      select: (concise: ValidateStrategy, verbose: ValidateStrategy) => TResult,
+    ): TResult
+  }>()
+})
+
 describe.each([
   ["getValidateOn(scope)", getValidateOnDefault],
   ["getValidateOn(scope, (concise) => concise)", getValidateOnConcise],

--- a/packages/react-impulse-form/tests/ImpulseFormValue/isSubmitting.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormValue/isSubmitting.spec.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import type { Scope } from "react-impulse"
 
 import { ImpulseFormValue } from "../../src"
 import { wait } from "../common"
@@ -19,6 +20,12 @@ const setupValue =
 
 beforeAll(() => {
   vi.useFakeTimers()
+})
+
+it("matches the type signature", () => {
+  const form = setupValue()()
+
+  expectTypeOf(form.isSubmitting).toEqualTypeOf<(scope: Scope) => boolean>()
 })
 
 describe.each([

--- a/packages/react-impulse-form/tests/ImpulseFormValue/isValidated.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormValue/isValidated.spec.ts
@@ -29,6 +29,19 @@ const isValidatedVerbose = (
   value: ImpulseFormValue<string, number>,
 ) => value.isValidated(scope, (_, verbose) => verbose)
 
+it("matches the type signature", () => {
+  const form = setup()
+
+  expectTypeOf(form.isValidated).toEqualTypeOf<{
+    (scope: Scope): boolean
+
+    <TResult>(
+      scope: Scope,
+      select: (concise: boolean, verbose: boolean) => TResult,
+    ): TResult
+  }>()
+})
+
 describe.each([
   ["isValidated(scope)", isValidatedDefault],
   ["isValidated(scope, (concise) => concise)", isValidatedConcise],

--- a/packages/react-impulse-form/tests/ImpulseFormValue/onSubmit.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormValue/onSubmit.spec.ts
@@ -9,6 +9,14 @@ beforeAll(() => {
   vi.useFakeTimers()
 })
 
+it("matches the type signature", () => {
+  const form = ImpulseFormValue.of("value")
+
+  expectTypeOf(form.onSubmit).toEqualTypeOf<
+    (listener: (value: string) => void | Promise<unknown>) => VoidFunction
+  >()
+})
+
 describe("onSubmit(listener)", () => {
   it("provides validated value", () => {
     const form = ImpulseFormValue.of("value", {

--- a/packages/react-impulse-form/tests/ImpulseFormValue/setValidateOn.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormValue/setValidateOn.spec.ts
@@ -9,15 +9,15 @@ const setup = (options?: ImpulseFormValueOptions<string>) => {
   return ImpulseFormValue.of("", options)
 }
 
+it("matches the type signature", () => {
+  const value = setup()
+
+  expectTypeOf(value.setValidateOn).toEqualTypeOf<
+    (setter: Setter<ValidateStrategy>) => void
+  >()
+})
+
 describe("setValidateOn(..)", () => {
-  it("matches the type signature", () => {
-    const value = setup()
-
-    expectTypeOf(value.setValidateOn).toEqualTypeOf<
-      (setter: Setter<ValidateStrategy>) => void
-    >()
-  })
-
   it("sets the ValidateStrategy", ({ scope }) => {
     const value = setup({ validateOn: "onInit" })
 


### PR DESCRIPTION
Breaking change:

- Rename `ImpulseFormValueOptions.compare` to `ImpulseFormValueOptions.isOriginalValueEqual`
- `ImpulseFormValue#setOriginalValue` does not reset errors on call anymore. Call `ImpulseFormValue#setErrors([])` manually when needed.