### PR TITLE
Introduce `ImpulseFormList` 🎉

### DIFF
--- a/.changeset/slimy-shirts-drum.md
+++ b/.changeset/slimy-shirts-drum.md
@@ -1,0 +1,11 @@
+---
+"react-impulse-form": minor
+---
+
+Breaking changes:
+
+- `ImpulseFormShape#isValidated`, `ImpulseFormShape#isDirty`, and `ImpulseFormShape#isTouched` return `false` for empty shapes.
+
+Introduced:
+
+- `ImpulseFormList` class.

--- a/packages/react-impulse-form/CHANGELOG.md
+++ b/packages/react-impulse-form/CHANGELOG.md
@@ -59,7 +59,7 @@
     +ImpulseFormValue#setSchema(schema: Schema | null): void
     ```
 
-  Breaking change:
+  Breaking changes:
 
   - use `ImpulseForm#submit`, `ImpulseForm#getSubmitCount`, `ImpulseForm#isSubmitting` instead
 

--- a/packages/react-impulse-form/src/ImpulseForm.ts
+++ b/packages/react-impulse-form/src/ImpulseForm.ts
@@ -37,11 +37,15 @@ export abstract class ImpulseForm<
     return value instanceof ImpulseForm
   }
 
-  protected static _cloneWithRoot<TChildParams extends ImpulseFormParams>(
-    root: ImpulseForm,
+  protected static _cloneWithParent<TChildParams extends ImpulseFormParams>(
+    parent: ImpulseForm,
     child: ImpulseForm<TChildParams>,
   ): ImpulseForm<TChildParams> {
-    return child._cloneWithRoot(root)
+    if (child._root === parent._root) {
+      return child
+    }
+
+    return child._cloneWithParent(parent._root)
   }
 
   protected static _submitWith<TParams extends ImpulseFormParams>(
@@ -83,7 +87,7 @@ export abstract class ImpulseForm<
 
   protected abstract _getFocusFirstInvalidValue(): null | VoidFunction
 
-  protected abstract _cloneWithRoot(
+  protected abstract _cloneWithParent(
     root: null | ImpulseForm,
   ): ImpulseForm<TParams>
 
@@ -139,7 +143,7 @@ export abstract class ImpulseForm<
   }
 
   public clone(): ImpulseForm<TParams> {
-    return this._cloneWithRoot(null)
+    return this._cloneWithParent(null)
   }
 
   public isValid(scope: Scope): boolean {

--- a/packages/react-impulse-form/src/ImpulseForm.ts
+++ b/packages/react-impulse-form/src/ImpulseForm.ts
@@ -212,13 +212,17 @@ export abstract class ImpulseForm<
     ) => TResult,
   ): TResult
 
+  // TODO extend with select
   public abstract getOriginalValue(
     scope: Scope,
   ): TParams["originalValue.schema"]
+
   public abstract setOriginalValue(
     setter: TParams["originalValue.setter"],
   ): void
 
+  // TODO extend with select
   public abstract getInitialValue(scope: Scope): TParams["originalValue.schema"]
+
   public abstract setInitialValue(setter: TParams["originalValue.setter"]): void
 }

--- a/packages/react-impulse-form/src/ImpulseForm.ts
+++ b/packages/react-impulse-form/src/ImpulseForm.ts
@@ -37,7 +37,7 @@ export abstract class ImpulseForm<
     return value instanceof ImpulseForm
   }
 
-  protected static _cloneWithParent<TChildParams extends ImpulseFormParams>(
+  protected static _childOf<TChildParams extends ImpulseFormParams>(
     parent: ImpulseForm,
     child: ImpulseForm<TChildParams>,
   ): ImpulseForm<TChildParams> {
@@ -45,7 +45,7 @@ export abstract class ImpulseForm<
       return child
     }
 
-    return child._cloneWithParent(parent._root)
+    return child._childOf(parent._root)
   }
 
   protected static _submitWith<TParams extends ImpulseFormParams>(
@@ -87,9 +87,7 @@ export abstract class ImpulseForm<
 
   protected abstract _getFocusFirstInvalidValue(): null | VoidFunction
 
-  protected abstract _cloneWithParent(
-    root: null | ImpulseForm,
-  ): ImpulseForm<TParams>
+  protected abstract _childOf(parent: null | ImpulseForm): ImpulseForm<TParams>
 
   protected abstract _setValidated(isValidated: boolean): void
 
@@ -143,7 +141,7 @@ export abstract class ImpulseForm<
   }
 
   public clone(): ImpulseForm<TParams> {
-    return this._cloneWithParent(null)
+    return this._childOf(null)
   }
 
   public isValid(scope: Scope): boolean {

--- a/packages/react-impulse-form/src/ImpulseFormList.ts
+++ b/packages/react-impulse-form/src/ImpulseFormList.ts
@@ -2,7 +2,6 @@ import {
   type Scope,
   batch,
   identity,
-  isBoolean,
   isFunction,
   isTruthy,
   isDefined,
@@ -208,6 +207,7 @@ export class ImpulseFormList<
     getCurrent: (scope: Scope) => [TElementValueLeft, TElementValueRight],
     setNext: (element: TElement, next: TGenericValue | TElementSetter) => void,
   ): void
+
   private _setFormElements<
     TElementSetter,
     TElementValue,
@@ -220,6 +220,7 @@ export class ImpulseFormList<
     getCurrent: (scope: Scope) => [TElementValue],
     setNext: (element: TElement, next: TGenericValue | TElementSetter) => void,
   ): void
+
   private _setFormElements<
     TElementSetter,
     TElementValueLeft,
@@ -316,7 +317,6 @@ export class ImpulseFormList<
     return this._elements.getValue(scope, select)
   }
 
-  // TODO add tests
   public getErrors(scope: Scope): ImpulseFormListErrorSchema<TElement>
   public getErrors<TResult>(
     scope: Scope,
@@ -345,26 +345,12 @@ export class ImpulseFormList<
     )
   }
 
-  public setErrors(errors: ImpulseFormListErrorSetter<TElement>): void {
-    batch((scope) => {
-      const nextErrors = isFunction(errors)
-        ? errors(this.getErrors(scope, (_, verbose) => verbose))
-        : errors
-
-      for (const [key, field] of Object.entries(this.fields)) {
-        const nextFieldTouched =
-          nextErrors == null
-            ? nextErrors
-            : nextErrors[key as keyof typeof nextErrors]
-
-        if (
-          ImpulseForm.isImpulseForm(field) &&
-          nextFieldTouched !== undefined
-        ) {
-          field.setErrors(nextFieldTouched)
-        }
-      }
-    })
+  public setErrors(setter: ImpulseFormListErrorSetter<TElement>): void {
+    this._setFormElements(
+      setter,
+      (scope) => [this.getErrors(scope, (_, verbose) => verbose)],
+      (element, next) => element.setErrors(next),
+    )
   }
 
   public isValidated(scope: Scope): boolean

--- a/packages/react-impulse-form/src/ImpulseFormList.ts
+++ b/packages/react-impulse-form/src/ImpulseFormList.ts
@@ -10,14 +10,7 @@ import {
   Impulse,
   untrack,
 } from "./dependencies"
-import {
-  type Setter,
-  forEach2,
-  isTrue,
-  shallowArrayEquals,
-  isFalse,
-  uniq,
-} from "./utils"
+import { type Setter, isTrue, shallowArrayEquals, isFalse, uniq } from "./utils"
 import { type GetImpulseFormParam, ImpulseForm } from "./ImpulseForm"
 import { VALIDATE_ON_TOUCH, type ValidateStrategy } from "./ValidateStrategy"
 
@@ -237,24 +230,17 @@ export class ImpulseFormList<
     setNext: (element: TElement, next: TGenericValue | TElementSetter) => void,
   ): void {
     batch((scope) => {
-      const elements = this._elements.getValue(scope)
       const nextInitialValue = isFunction(setter)
         ? setter(...getCurrent(scope))
         : setter
 
-      if (isArray(nextInitialValue)) {
-        forEach2(
-          (element, next) => {
-            if (isDefined.strict(next)) {
-              setNext(element, next)
-            }
-          },
-          elements,
-          nextInitialValue,
-        )
-      } else {
-        for (const element of elements) {
-          setNext(element, nextInitialValue)
+      for (const [index, element] of this._elements.getValue(scope).entries()) {
+        const next = isArray(nextInitialValue)
+          ? nextInitialValue.at(index)
+          : nextInitialValue
+
+        if (isDefined.strict(next)) {
+          setNext(element, next)
         }
       }
     })

--- a/packages/react-impulse-form/src/ImpulseFormList.ts
+++ b/packages/react-impulse-form/src/ImpulseFormList.ts
@@ -46,13 +46,13 @@ export type ImpulseFormListFlagSchema<TElement extends ImpulseForm> =
   | boolean
   | ReadonlyArray<GetImpulseFormParam<TElement, "flag.schema">>
 
-export type ImpulseFormShapeListSchemaVerbose<TElement extends ImpulseForm> =
+export type ImpulseFormListFlagSchemaVerbose<TElement extends ImpulseForm> =
   ReadonlyArray<GetImpulseFormParam<TElement, "flag.schema.verbose">>
 
 export type ImpulseFormListFlagSetter<TElement extends ImpulseForm> = Setter<
   | boolean
   | ReadonlyArray<undefined | GetImpulseFormParam<TElement, "flag.setter">>,
-  [ImpulseFormShapeListSchemaVerbose<TElement>]
+  [ImpulseFormListFlagSchemaVerbose<TElement>]
 >
 
 export type ImpulseFormListValidateOnSchema<TElement extends ImpulseForm> =
@@ -105,7 +105,7 @@ export class ImpulseFormList<
 
   "flag.setter": ImpulseFormListFlagSetter<TElement>
   "flag.schema": ImpulseFormListFlagSchema<TElement>
-  "flag.schema.verbose": ImpulseFormShapeListSchemaVerbose<TElement>
+  "flag.schema.verbose": ImpulseFormListFlagSchemaVerbose<TElement>
 
   "validateOn.setter": ImpulseFormListValidateOnSetter<TElement>
   "validateOn.schema": ImpulseFormListValidateOnSchema<TElement>
@@ -125,7 +125,7 @@ export class ImpulseFormList<
       errors,
     }: ImpulseFormListOptions<TElement> = {},
   ): ImpulseFormList<TElement> {
-    const shape = new ImpulseFormList(
+    const list = new ImpulseFormList(
       null,
       Impulse.of(elements, {
         compare: shallowArrayEquals,
@@ -134,28 +134,28 @@ export class ImpulseFormList<
 
     batch(() => {
       if (isDefined.strict(touched)) {
-        shape.setTouched(touched)
+        list.setTouched(touched)
       }
 
       if (isDefined.strict(initialValue)) {
-        shape.setInitialValue(initialValue)
+        list.setInitialValue(initialValue)
       }
 
       if (isDefined.strict(originalValue)) {
-        shape.setOriginalValue(originalValue)
+        list.setOriginalValue(originalValue)
       }
 
       if (isDefined(validateOn)) {
-        shape.setValidateOn(validateOn)
+        list.setValidateOn(validateOn)
       }
 
       // TODO add test against null
       if (isDefined.strict(errors)) {
-        shape.setErrors(errors)
+        list.setErrors(errors)
       }
     })
 
-    return shape
+    return list
   }
 
   protected constructor(
@@ -336,14 +336,14 @@ export class ImpulseFormList<
     scope: Scope,
     select: (
       concise: ImpulseFormListFlagSchema<TElement>,
-      verbose: ImpulseFormShapeListSchemaVerbose<TElement>,
+      verbose: ImpulseFormListFlagSchemaVerbose<TElement>,
     ) => TResult,
   ): TResult
   public isValidated<TResult = boolean>(
     scope: Scope,
     select: (
       concise: ImpulseFormListFlagSchema<TElement>,
-      verbose: ImpulseFormShapeListSchemaVerbose<TElement>,
+      verbose: ImpulseFormListFlagSchemaVerbose<TElement>,
     ) => TResult = isTrue as unknown as typeof select,
   ): TResult {
     const [validatedConcise, valueVerbose] = this._mapFormElements(
@@ -358,7 +358,7 @@ export class ImpulseFormList<
         : validatedConcise.every(isTrue)
           ? true
           : (validatedConcise as ImpulseFormListFlagSchema<TElement>),
-      valueVerbose as ImpulseFormShapeListSchemaVerbose<TElement>,
+      valueVerbose as ImpulseFormListFlagSchemaVerbose<TElement>,
     )
   }
 
@@ -414,14 +414,14 @@ export class ImpulseFormList<
     scope: Scope,
     select: (
       concise: ImpulseFormListFlagSchema<TElement>,
-      verbose: ImpulseFormShapeListSchemaVerbose<TElement>,
+      verbose: ImpulseFormListFlagSchemaVerbose<TElement>,
     ) => TResult,
   ): TResult
   public isTouched<TResult = boolean>(
     scope: Scope,
     select: (
       concise: ImpulseFormListFlagSchema<TElement>,
-      verbose: ImpulseFormShapeListSchemaVerbose<TElement>,
+      verbose: ImpulseFormListFlagSchemaVerbose<TElement>,
     ) => TResult = isTruthy as unknown as typeof select,
   ): TResult {
     const [touchedConcise, touchedVerbose] = this._mapFormElements(
@@ -435,7 +435,7 @@ export class ImpulseFormList<
         : touchedConcise.every(isTrue)
           ? true
           : (touchedConcise as ImpulseFormListFlagSchema<TElement>),
-      touchedVerbose as ImpulseFormShapeListSchemaVerbose<TElement>,
+      touchedVerbose as ImpulseFormListFlagSchemaVerbose<TElement>,
     )
   }
 
@@ -462,14 +462,14 @@ export class ImpulseFormList<
     scope: Scope,
     select: (
       concise: ImpulseFormListFlagSchema<TElement>,
-      verbose: ImpulseFormShapeListSchemaVerbose<TElement>,
+      verbose: ImpulseFormListFlagSchemaVerbose<TElement>,
     ) => TResult,
   ): TResult
   public isDirty<TResult = boolean>(
     scope: Scope,
     select: (
       concise: ImpulseFormListFlagSchema<TElement>,
-      verbose: ImpulseFormShapeListSchemaVerbose<TElement>,
+      verbose: ImpulseFormListFlagSchemaVerbose<TElement>,
     ) => TResult = isTruthy as unknown as typeof select,
   ): TResult {
     const [dirtyConcise, dirtyVerbose] = this._mapFormElements(scope, (form) =>
@@ -482,7 +482,7 @@ export class ImpulseFormList<
         : dirtyConcise.every(isTrue)
           ? true
           : (dirtyConcise as ImpulseFormListFlagSchema<TElement>),
-      dirtyVerbose as ImpulseFormShapeListSchemaVerbose<TElement>,
+      dirtyVerbose as ImpulseFormListFlagSchemaVerbose<TElement>,
     )
   }
 

--- a/packages/react-impulse-form/src/ImpulseFormList.ts
+++ b/packages/react-impulse-form/src/ImpulseFormList.ts
@@ -165,9 +165,9 @@ export class ImpulseFormList<
     super(root)
 
     this._elements.setValue((elements) => {
-      return elements.map(
-        (element) => ImpulseForm._cloneWithRoot(this, element) as TElement,
-      )
+      return elements.map((element) => {
+        return ImpulseForm._cloneWithRoot(root ?? this, element) as TElement
+      })
     })
   }
 

--- a/packages/react-impulse-form/src/ImpulseFormList.ts
+++ b/packages/react-impulse-form/src/ImpulseFormList.ts
@@ -390,10 +390,10 @@ export class ImpulseFormList<
     )
 
     return select(
-      validatedConcise.every(isTrue)
-        ? true
-        : validatedConcise.every(isFalse)
-          ? false
+      validatedConcise.every(isFalse)
+        ? false
+        : validatedConcise.every(isTrue)
+          ? true
           : (validatedConcise as ImpulseFormListFlagSchema<TElement>),
       valueVerbose as ImpulseFormShapeListSchemaVerbose<TElement>,
     )
@@ -456,7 +456,6 @@ export class ImpulseFormList<
     )
   }
 
-  // TODO add tests
   public isTouched(scope: Scope): boolean
   public isTouched<TResult>(
     scope: Scope,
@@ -487,7 +486,6 @@ export class ImpulseFormList<
     )
   }
 
-  // TODO add tests
   public setTouched(setter: ImpulseFormListFlagSetter<TElement>): void {
     this._setFormElements(
       setter,

--- a/packages/react-impulse-form/src/ImpulseFormList.ts
+++ b/packages/react-impulse-form/src/ImpulseFormList.ts
@@ -166,7 +166,7 @@ export class ImpulseFormList<
 
     this._elements.setValue((elements) => {
       return elements.map((element) => {
-        return ImpulseForm._cloneWithParent(this, element) as TElement
+        return ImpulseForm._childOf(this, element) as TElement
       })
     })
   }
@@ -268,10 +268,8 @@ export class ImpulseFormList<
     return null
   }
 
-  protected _cloneWithParent(
-    root: null | ImpulseForm,
-  ): ImpulseFormList<TElement> {
-    return new ImpulseFormList(root, this._elements.clone())
+  protected _childOf(parent: null | ImpulseForm): ImpulseFormList<TElement> {
+    return new ImpulseFormList(parent, this._elements.clone())
   }
 
   protected _setValidated(isValidated: boolean): void {
@@ -301,7 +299,7 @@ export class ImpulseFormList<
       const nextElements = isFunction(setter) ? setter(elements, scope) : setter
 
       return nextElements.map((element) => {
-        return ImpulseForm._cloneWithParent(this, element) as TElement
+        return ImpulseForm._childOf(this, element) as TElement
       })
     })
   }

--- a/packages/react-impulse-form/src/ImpulseFormList.ts
+++ b/packages/react-impulse-form/src/ImpulseFormList.ts
@@ -263,13 +263,8 @@ export class ImpulseFormList<
   protected _submitWith(
     value: ImpulseFormListValueSchema<TElement>,
   ): ReadonlyArray<void | Promise<unknown>> {
-    // TODO DRY
-    const promises = Object.entries(this.fields).flatMap(([key, field]) => {
-      if (!ImpulseForm.isImpulseForm(field)) {
-        return []
-      }
-
-      return ImpulseForm._submitWith(field, value[key as keyof typeof value])
+    const promises = untrack(this._elements).flatMap((element, index) => {
+      return ImpulseForm._submitWith(element, value[index])
     })
 
     return [...super._submitWith(value), ...promises]

--- a/packages/react-impulse-form/src/ImpulseFormList.ts
+++ b/packages/react-impulse-form/src/ImpulseFormList.ts
@@ -294,13 +294,14 @@ export class ImpulseFormList<
     return this._elements.getValue(scope, select)
   }
 
-  public setElements(setter: Setter<ReadonlyArray<TElement>>): void {
-    batch(() => {
-      this._elements.setValue(setter)
-      this._elements.setValue((elements) => {
-        return elements.map((element) => {
-          return ImpulseForm._cloneWithParent(this, element) as TElement
-        })
+  public setElements(
+    setter: Setter<ReadonlyArray<TElement>, [ReadonlyArray<TElement>, Scope]>,
+  ): void {
+    this._elements.setValue((elements, scope) => {
+      const nextElements = isFunction(setter) ? setter(elements, scope) : setter
+
+      return nextElements.map((element) => {
+        return ImpulseForm._cloneWithParent(this, element) as TElement
       })
     })
   }

--- a/packages/react-impulse-form/src/ImpulseFormList.ts
+++ b/packages/react-impulse-form/src/ImpulseFormList.ts
@@ -166,7 +166,7 @@ export class ImpulseFormList<
 
     this._elements.setValue((elements) => {
       return elements.map((element) => {
-        return ImpulseForm._cloneWithRoot(root ?? this, element) as TElement
+        return ImpulseForm._cloneWithParent(this, element) as TElement
       })
     })
   }
@@ -268,7 +268,7 @@ export class ImpulseFormList<
     return null
   }
 
-  protected _cloneWithRoot(
+  protected _cloneWithParent(
     root: null | ImpulseForm,
   ): ImpulseFormList<TElement> {
     return new ImpulseFormList(root, this._elements.clone())
@@ -292,6 +292,17 @@ export class ImpulseFormList<
     ) => TResult = identity as typeof select,
   ): TResult {
     return this._elements.getValue(scope, select)
+  }
+
+  public setElements(setter: Setter<ReadonlyArray<TElement>>): void {
+    batch(() => {
+      this._elements.setValue(setter)
+      this._elements.setValue((elements) => {
+        return elements.map((element) => {
+          return ImpulseForm._cloneWithParent(this, element) as TElement
+        })
+      })
+    })
   }
 
   public getErrors(scope: Scope): ImpulseFormListErrorSchema<TElement>

--- a/packages/react-impulse-form/src/ImpulseFormList.ts
+++ b/packages/react-impulse-form/src/ImpulseFormList.ts
@@ -1,0 +1,667 @@
+import {
+  type Scope,
+  batch,
+  identity,
+  isBoolean,
+  isFunction,
+  isTruthy,
+  isDefined,
+  isString,
+  Impulse,
+} from "./dependencies"
+import { isTrue, type Setter } from "./utils"
+import { type GetImpulseFormParam, ImpulseForm } from "./ImpulseForm"
+import { VALIDATE_ON_TOUCH, type ValidateStrategy } from "./ValidateStrategy"
+
+export type ImpulseFormListValueSchema<TElement extends ImpulseForm> =
+  ReadonlyArray<GetImpulseFormParam<TElement, "value.schema">>
+
+export type ImpulseFormListValueSchemaVerbose<TElement extends ImpulseForm> =
+  ReadonlyArray<GetImpulseFormParam<TElement, "value.schema.verbose">>
+
+export type ImpulseFormListOriginalValueSchema<TElement extends ImpulseForm> =
+  ReadonlyArray<GetImpulseFormParam<TElement, "originalValue.schema">>
+
+export type ImpulseFormListOriginalValueSetter<TElement extends ImpulseForm> =
+  Setter<
+    ReadonlyArray<
+      undefined | GetImpulseFormParam<TElement, "originalValue.setter">
+    >,
+    [originalValue: ImpulseFormListOriginalValueSchema<TElement>]
+  >
+
+export type ImpulseFormListOriginalValueResetter<TElement extends ImpulseForm> =
+  Setter<
+    ReadonlyArray<
+      undefined | GetImpulseFormParam<TElement, "originalValue.resetter">
+    >,
+    [
+      initialValue: ImpulseFormListOriginalValueSchema<TElement>,
+      originalValue: ImpulseFormListOriginalValueSchema<TElement>,
+    ]
+  >
+
+export type ImpulseFormListFlagSchema<TElement extends ImpulseForm> =
+  | boolean
+  | ReadonlyArray<GetImpulseFormParam<TElement, "flag.schema">>
+
+export type ImpulseFormShapeListSchemaVerbose<TElement extends ImpulseForm> =
+  ReadonlyArray<GetImpulseFormParam<TElement, "flag.schema.verbose">>
+
+export type ImpulseFormListFlagSetter<TElement extends ImpulseForm> = Setter<
+  | boolean
+  | ReadonlyArray<undefined | GetImpulseFormParam<TElement, "flag.setter">>,
+  [ImpulseFormShapeListSchemaVerbose<TElement>]
+>
+
+export type ImpulseFormListValidateOnSchema<TElement extends ImpulseForm> =
+  | ValidateStrategy
+  | ReadonlyArray<GetImpulseFormParam<TElement, "validateOn.schema">>
+export type ImpulseFormListValidateOnSchemaVerbose<
+  TElement extends ImpulseForm,
+> = ReadonlyArray<GetImpulseFormParam<TElement, "validateOn.schema.verbose">>
+
+export type ImpulseFormListValidateOnSetter<TElement extends ImpulseForm> =
+  Setter<
+    | ValidateStrategy
+    | ReadonlyArray<
+        undefined | GetImpulseFormParam<TElement, "validateOn.setter">
+      >,
+    [ImpulseFormListValidateOnSchemaVerbose<TElement>]
+  >
+
+export type ImpulseFormListErrorSetter<TElement extends ImpulseForm> = Setter<
+  null | ReadonlyArray<
+    undefined | GetImpulseFormParam<TElement, "errors.setter">
+  >,
+  [ImpulseFormListErrorSchemaVerbose<TElement>]
+>
+
+export type ImpulseFormListErrorSchema<TElement extends ImpulseForm> =
+  null | ReadonlyArray<GetImpulseFormParam<TElement, "errors.schema">>
+
+export type ImpulseFormListErrorSchemaVerbose<TElement extends ImpulseForm> =
+  ReadonlyArray<GetImpulseFormParam<TElement, "errors.schema.verbose">>
+
+export interface ImpulseFormListOptions<TElement extends ImpulseForm> {
+  // TODO add schema
+  touched?: ImpulseFormListFlagSetter<TElement>
+  initialValue?: ImpulseFormListOriginalValueSetter<TElement>
+  originalValue?: ImpulseFormListOriginalValueSetter<TElement>
+  validateOn?: ImpulseFormListValidateOnSetter<TElement>
+  errors?: ImpulseFormListErrorSetter<TElement>
+}
+
+export class ImpulseFormList<
+  TElement extends ImpulseForm = ImpulseForm,
+> extends ImpulseForm<{
+  "value.schema": ImpulseFormListValueSchema<TElement>
+  "value.schema.verbose": ImpulseFormListValueSchemaVerbose<TElement>
+
+  "originalValue.setter": ImpulseFormListOriginalValueSetter<TElement>
+  "originalValue.resetter": ImpulseFormListOriginalValueResetter<TElement>
+  "originalValue.schema": ImpulseFormListOriginalValueSchema<TElement>
+
+  "flag.setter": ImpulseFormListFlagSetter<TElement>
+  "flag.schema": ImpulseFormListFlagSchema<TElement>
+  "flag.schema.verbose": ImpulseFormShapeListSchemaVerbose<TElement>
+
+  "validateOn.setter": ImpulseFormListValidateOnSetter<TElement>
+  "validateOn.schema": ImpulseFormListValidateOnSchema<TElement>
+  "validateOn.schema.verbose": ImpulseFormListValidateOnSchemaVerbose<TElement>
+
+  "errors.setter": ImpulseFormListErrorSetter<TElement>
+  "errors.schema": ImpulseFormListErrorSchema<TElement>
+  "errors.schema.verbose": ImpulseFormListErrorSchemaVerbose<TElement>
+}> {
+  public static of<TElement extends ImpulseForm>(
+    elements: ReadonlyArray<TElement>,
+    {
+      touched,
+      initialValue,
+      originalValue,
+      validateOn,
+      errors,
+    }: ImpulseFormListOptions<TElement> = {},
+  ): ImpulseFormList<TElement> {
+    const shape = new ImpulseFormList(null, elements)
+
+    batch(() => {
+      if (isDefined.strict(touched)) {
+        shape.setTouched(touched)
+      }
+
+      if (isDefined.strict(initialValue)) {
+        shape.setInitialValue(initialValue)
+      }
+
+      if (isDefined.strict(originalValue)) {
+        shape.setOriginalValue(originalValue)
+      }
+
+      if (isDefined(validateOn)) {
+        shape.setValidateOn(validateOn)
+      }
+
+      // TODO add test against null
+      if (isDefined.strict(errors)) {
+        shape.setErrors(errors)
+      }
+    })
+
+    return shape
+  }
+
+  private readonly _elements: Impulse<ReadonlyArray<TElement>>
+
+  protected constructor(
+    root: null | ImpulseForm,
+    elements: ReadonlyArray<TElement>,
+  ) {
+    super(root)
+
+    const elementsWithRoot: ReadonlyArray<TElement> = elements.map(
+      (element) => ImpulseForm._cloneWithRoot(this, element) as TElement,
+    )
+
+    this._elements = Impulse.of(elementsWithRoot)
+  }
+
+  private _mapFormFields<TResult>(
+    fn: (form: ImpulseForm) => TResult,
+  ): Readonly<Record<keyof TElement, TResult>> {
+    const acc = {} as Record<keyof TElement, TResult>
+
+    for (const [key, field] of Object.entries(this.fields)) {
+      const value = ImpulseForm.isImpulseForm(field)
+        ? fn(field)
+        : (field as TResult)
+
+      acc[key as keyof typeof acc] = value
+    }
+
+    return acc
+  }
+
+  protected _submitWith(
+    value: ImpulseFormListValueSchema<TElement>,
+  ): ReadonlyArray<void | Promise<unknown>> {
+    // TODO DRY
+    const promises = Object.entries(this.fields).flatMap(([key, field]) => {
+      if (!ImpulseForm.isImpulseForm(field)) {
+        return []
+      }
+
+      return ImpulseForm._submitWith(field, value[key as keyof typeof value])
+    })
+
+    return [...super._submitWith(value), ...promises]
+  }
+
+  protected _getFocusFirstInvalidValue(): VoidFunction | null {
+    // TODO DRY
+    // TODO add custom ordering
+    for (const field of Object.values(this.fields)) {
+      if (ImpulseForm.isImpulseForm(field)) {
+        const focus = ImpulseForm._getFocusFirstInvalidValue(field)
+
+        if (focus != null) {
+          return focus
+        }
+      }
+    }
+
+    return null
+  }
+
+  protected _cloneWithRoot(
+    root: null | ImpulseForm,
+  ): ImpulseFormList<TElement> {
+    return new ImpulseFormList(root, this.fields)
+  }
+
+  protected _setValidated(isValidated: boolean): void {
+    for (const field of Object.values(this.fields)) {
+      if (ImpulseForm.isImpulseForm(field)) {
+        ImpulseForm._setValidated(field, isValidated)
+      }
+    }
+  }
+
+  public getElements(scope: Scope): ReadonlyArray<TElement>
+  public getElements<TResult>(
+    scope: Scope,
+    select: (elements: ReadonlyArray<TElement>) => TResult,
+  ): TResult
+  public getElements<TResult>(
+    scope: Scope,
+    select: (
+      elements: ReadonlyArray<TElement>,
+    ) => TResult = identity as typeof select,
+  ): TResult {
+    return this._elements.getValue(scope, select)
+  }
+
+  public getErrors(scope: Scope): ImpulseFormListErrorSchema<TElement>
+  public getErrors<TResult>(
+    scope: Scope,
+    select: (
+      concise: ImpulseFormListErrorSchema<TElement>,
+      verbose: ImpulseFormListErrorSchemaVerbose<TElement>,
+    ) => TResult,
+  ): TResult
+  public getErrors<TResult = ImpulseFormListErrorSchema<TElement>>(
+    scope: Scope,
+    select: (
+      concise: ImpulseFormListErrorSchema<TElement>,
+      verbose: ImpulseFormListErrorSchemaVerbose<TElement>,
+    ) => TResult = identity as typeof select,
+  ): TResult {
+    // TODO DRY
+    let errorsNone = true
+    // make it easier for TS
+    const errorsConcise = {} as Record<string, unknown>
+    const errorsVerbose = {} as Record<string, unknown>
+
+    for (const [key, field] of Object.entries(this.fields)) {
+      if (ImpulseForm.isImpulseForm(field)) {
+        const errors = field.getErrors(scope, (concise, verbose) => ({
+          concise,
+          verbose,
+        }))
+
+        errorsNone = errorsNone && errors.concise == null
+        errorsConcise[key] = errors.concise
+        errorsVerbose[key] = errors.verbose
+      }
+    }
+
+    return select(
+      errorsNone
+        ? null
+        : (errorsConcise as unknown as ImpulseFormListErrorSchema<TElement>),
+      errorsVerbose as unknown as ImpulseFormListErrorSchemaVerbose<TElement>,
+    )
+  }
+
+  public setErrors(errors: ImpulseFormListErrorSetter<TElement>): void {
+    batch((scope) => {
+      const nextErrors = isFunction(errors)
+        ? errors(this.getErrors(scope, (_, verbose) => verbose))
+        : errors
+
+      for (const [key, field] of Object.entries(this.fields)) {
+        const nextFieldTouched =
+          nextErrors == null
+            ? nextErrors
+            : nextErrors[key as keyof typeof nextErrors]
+
+        if (
+          ImpulseForm.isImpulseForm(field) &&
+          nextFieldTouched !== undefined
+        ) {
+          field.setErrors(nextFieldTouched)
+        }
+      }
+    })
+  }
+
+  /**
+   * @param scope
+   *
+   * @returns true when ALL fields are validated, otherwise false
+   */
+  public isValidated(scope: Scope): boolean
+
+  public isValidated<TResult>(
+    scope: Scope,
+    select: (
+      concise: ImpulseFormListFlagSchema<TElement>,
+      verbose: ImpulseFormShapeListSchemaVerbose<TElement>,
+    ) => TResult,
+  ): TResult
+  public isValidated<TResult = boolean>(
+    scope: Scope,
+    select: (
+      concise: ImpulseFormListFlagSchema<TElement>,
+      verbose: ImpulseFormShapeListSchemaVerbose<TElement>,
+    ) => TResult = isTrue as unknown as typeof select,
+  ): TResult {
+    // TODO DRY
+    let validatedAll = true
+    let validatedNone = true
+    // make it easier for TS
+    const validatedConcise = {} as Record<string, unknown>
+    const validatedVerbose = {} as Record<string, unknown>
+
+    for (const [key, field] of Object.entries(this.fields)) {
+      if (ImpulseForm.isImpulseForm(field)) {
+        const validated = field.isValidated(scope, (concise, verbose) => ({
+          concise,
+          verbose,
+        }))
+
+        validatedAll = validatedAll && validated.concise === true
+        validatedNone = validatedNone && validated.concise === false
+        validatedConcise[key] = validated.concise
+        validatedVerbose[key] = validated.verbose
+      }
+    }
+
+    return select(
+      validatedAll
+        ? true
+        : validatedNone
+          ? false
+          : (validatedConcise as unknown as ImpulseFormListFlagSchema<TElement>),
+      validatedVerbose as unknown as ImpulseFormShapeListSchemaVerbose<TElement>,
+    )
+  }
+
+  public getValidateOn(scope: Scope): ImpulseFormListValidateOnSchema<TElement>
+  public getValidateOn<TResult>(
+    scope: Scope,
+    select: (
+      concise: ImpulseFormListValidateOnSchema<TElement>,
+      verbose: ImpulseFormListValidateOnSchemaVerbose<TElement>,
+    ) => TResult,
+  ): TResult
+  public getValidateOn<TResult = ImpulseFormListValidateOnSchema<TElement>>(
+    scope: Scope,
+    select: (
+      concise: ImpulseFormListValidateOnSchema<TElement>,
+      verbose: ImpulseFormListValidateOnSchemaVerbose<TElement>,
+    ) => TResult = identity as typeof select,
+  ): TResult {
+    // TODO DRY
+    // make it easier for TS
+    const validateOnConcise = {} as Record<string, unknown>
+    const validateOnVerbose = {} as Record<string, unknown>
+
+    for (const [key, field] of Object.entries(this.fields)) {
+      if (ImpulseForm.isImpulseForm(field)) {
+        const validateOn = field.getValidateOn(scope, (concise, verbose) => ({
+          concise,
+          verbose,
+        }))
+
+        validateOnConcise[key] = validateOn.concise
+        validateOnVerbose[key] = validateOn.verbose
+      }
+    }
+
+    const validateOnConciseValues = Object.values(validateOnConcise)
+
+    return select(
+      validateOnConciseValues.length === 0
+        ? // defaults to "onTouch"
+          VALIDATE_ON_TOUCH
+        : validateOnConciseValues.every(isString) &&
+            new Set(validateOnConciseValues).size === 1
+          ? (validateOnConciseValues[0] as ValidateStrategy)
+          : (validateOnConcise as unknown as ImpulseFormListValidateOnSchema<TElement>),
+      validateOnVerbose as unknown as ImpulseFormListValidateOnSchemaVerbose<TElement>,
+    )
+  }
+
+  public setValidateOn(
+    validateOn: ImpulseFormListValidateOnSetter<TElement>,
+  ): void {
+    batch((scope) => {
+      const nextValidateOn = isFunction(validateOn)
+        ? validateOn(this.getValidateOn(scope, (_, verbose) => verbose))
+        : validateOn
+
+      for (const [key, field] of Object.entries(this.fields)) {
+        const nextFieldTouched = isString(nextValidateOn)
+          ? nextValidateOn
+          : nextValidateOn[key as keyof typeof nextValidateOn]
+
+        if (
+          ImpulseForm.isImpulseForm(field) &&
+          isDefined.strict(nextFieldTouched)
+        ) {
+          field.setValidateOn(nextFieldTouched)
+        }
+      }
+    })
+  }
+
+  public isTouched(scope: Scope): boolean
+  public isTouched<TResult>(
+    scope: Scope,
+    select: (
+      concise: ImpulseFormListFlagSchema<TElement>,
+      verbose: ImpulseFormShapeListSchemaVerbose<TElement>,
+    ) => TResult,
+  ): TResult
+  public isTouched<TResult = boolean>(
+    scope: Scope,
+    select: (
+      concise: ImpulseFormListFlagSchema<TElement>,
+      verbose: ImpulseFormShapeListSchemaVerbose<TElement>,
+    ) => TResult = isTruthy as unknown as typeof select,
+  ): TResult {
+    // TODO DRY
+    let touchedAll = true
+    let touchedNone = true
+    // make it easier for TS
+    const touchedConcise = {} as Record<string, unknown>
+    const touchedVerbose = {} as Record<string, unknown>
+
+    for (const [key, field] of Object.entries(this.fields)) {
+      if (ImpulseForm.isImpulseForm(field)) {
+        const touched = field.isTouched(scope, (concise, verbose) => ({
+          concise,
+          verbose,
+        }))
+
+        touchedAll = touchedAll && touched.concise === true
+        touchedNone = touchedNone && touched.concise === false
+        touchedConcise[key] = touched.concise
+        touchedVerbose[key] = touched.verbose
+      }
+    }
+
+    return select(
+      touchedAll
+        ? true
+        : touchedNone
+          ? false
+          : (touchedConcise as unknown as ImpulseFormListFlagSchema<TElement>),
+      touchedVerbose as unknown as ImpulseFormShapeListSchemaVerbose<TElement>,
+    )
+  }
+
+  public setTouched(touched: ImpulseFormListFlagSetter<TElement>): void {
+    batch((scope) => {
+      const nextTouched = isFunction(touched)
+        ? touched(this.isTouched(scope, (_, verbose) => verbose))
+        : touched
+
+      for (const [key, field] of Object.entries(this.fields)) {
+        const nextFieldTouched = isBoolean(nextTouched)
+          ? nextTouched
+          : nextTouched[key as keyof typeof nextTouched]
+
+        if (
+          ImpulseForm.isImpulseForm(field) &&
+          nextFieldTouched !== undefined
+        ) {
+          field.setTouched(nextFieldTouched)
+        }
+      }
+    })
+  }
+
+  public reset(
+    resetter: ImpulseFormListOriginalValueResetter<TElement> = identity as typeof resetter,
+  ): void {
+    // TODO DRY
+    batch((scope) => {
+      const resetValue = isFunction(resetter)
+        ? resetter(this.getInitialValue(scope), this.getOriginalValue(scope))
+        : resetter
+
+      for (const [key, field] of Object.entries(this.fields)) {
+        if (ImpulseForm.isImpulseForm(field)) {
+          field.reset(resetValue[key as keyof typeof resetValue])
+        }
+      }
+    })
+  }
+
+  public isDirty(scope: Scope): boolean
+  public isDirty<TResult>(
+    scope: Scope,
+    select: (
+      concise: ImpulseFormListFlagSchema<TElement>,
+      verbose: ImpulseFormShapeListSchemaVerbose<TElement>,
+    ) => TResult,
+  ): TResult
+  public isDirty<TResult = boolean>(
+    scope: Scope,
+    select: (
+      concise: ImpulseFormListFlagSchema<TElement>,
+      verbose: ImpulseFormShapeListSchemaVerbose<TElement>,
+    ) => TResult = isTruthy as unknown as typeof select,
+  ): TResult {
+    // TODO DRY
+    let touchedAll = true
+    let touchedNone = true
+    // make it easier for TS
+    const touchedConcise = {} as Record<string, unknown>
+    const touchedVerbose = {} as Record<string, unknown>
+
+    for (const [key, field] of Object.entries(this.fields)) {
+      if (ImpulseForm.isImpulseForm(field)) {
+        const touched = field.isDirty(scope, (concise, verbose) => ({
+          concise,
+          verbose,
+        }))
+
+        touchedAll = touchedAll && touched.concise === true
+        touchedNone = touchedNone && touched.concise === false
+        touchedConcise[key] = touched.concise
+        touchedVerbose[key] = touched.verbose
+      }
+    }
+
+    return select(
+      touchedAll
+        ? true
+        : touchedNone
+          ? false
+          : (touchedConcise as unknown as ImpulseFormListFlagSchema<TElement>),
+      touchedVerbose as unknown as ImpulseFormShapeListSchemaVerbose<TElement>,
+    )
+  }
+
+  public getValue(scope: Scope): null | ImpulseFormListValueSchema<TElement>
+  public getValue<TResult>(
+    scope: Scope,
+    select: (
+      concise: null | ImpulseFormListValueSchema<TElement>,
+      verbose: ImpulseFormListValueSchemaVerbose<TElement>,
+    ) => TResult,
+  ): TResult
+  public getValue<TResult = null | ImpulseFormListValueSchema<TElement>>(
+    scope: Scope,
+    select: (
+      concise: null | ImpulseFormListValueSchema<TElement>,
+      verbose: ImpulseFormListValueSchemaVerbose<TElement>,
+    ) => TResult = identity as typeof select,
+  ): TResult {
+    let allValid = true
+    // make it easier for TS
+    const valueConcise = {} as Record<string, unknown>
+    const valueVerbose = {} as Record<string, unknown>
+
+    for (const [key, field] of Object.entries(this.fields)) {
+      if (ImpulseForm.isImpulseForm(field)) {
+        const value = field.getValue(scope, (concise, verbose) => ({
+          concise,
+          verbose,
+        }))
+
+        allValid = allValid && value.concise !== null
+        valueConcise[key] = value.concise
+        valueVerbose[key] = value.verbose
+      } else {
+        valueConcise[key] = field
+        valueVerbose[key] = field
+      }
+    }
+
+    return select(
+      allValid
+        ? (valueConcise as unknown as ImpulseFormListValueSchema<TElement>)
+        : null,
+      valueVerbose as unknown as ImpulseFormListValueSchemaVerbose<TElement>,
+    )
+  }
+
+  public getOriginalValue(
+    scope: Scope,
+  ): ImpulseFormListOriginalValueSchema<TElement> {
+    const originalValue = this._mapFormFields((form) =>
+      form.getOriginalValue(scope),
+    )
+
+    return originalValue as unknown as ImpulseFormListOriginalValueSchema<TElement>
+  }
+
+  public setOriginalValue(
+    setter: ImpulseFormListOriginalValueSetter<TElement>,
+  ): void {
+    batch((scope) => {
+      const nextOriginalValue = isFunction(setter)
+        ? setter(this.getOriginalValue(scope))
+        : setter
+
+      for (const [key, field] of Object.entries(this.fields)) {
+        const nextFieldOriginalValue =
+          nextOriginalValue[key as keyof typeof nextOriginalValue]
+
+        if (
+          ImpulseForm.isImpulseForm(field) &&
+          nextFieldOriginalValue !== undefined
+        ) {
+          field.setOriginalValue(nextFieldOriginalValue)
+        }
+      }
+    })
+  }
+
+  public getInitialValue(
+    scope: Scope,
+  ): ImpulseFormListOriginalValueSchema<TElement> {
+    const originalValue = this._mapFormFields((form) =>
+      form.getInitialValue(scope),
+    )
+
+    return originalValue as unknown as ImpulseFormListOriginalValueSchema<TElement>
+  }
+
+  public setInitialValue(
+    setter: ImpulseFormListOriginalValueSetter<TElement>,
+  ): void {
+    batch((scope) => {
+      const nextInitialValue = isFunction(setter)
+        ? setter(this.getInitialValue(scope))
+        : setter
+
+      for (const [key, field] of Object.entries(this.fields)) {
+        const nextFieldInitialValue =
+          nextInitialValue[key as keyof typeof nextInitialValue]
+
+        if (
+          ImpulseForm.isImpulseForm(field) &&
+          nextFieldInitialValue !== undefined
+        ) {
+          field.setInitialValue(nextFieldInitialValue)
+        }
+      }
+    })
+  }
+}

--- a/packages/react-impulse-form/src/ImpulseFormList.ts
+++ b/packages/react-impulse-form/src/ImpulseFormList.ts
@@ -367,7 +367,6 @@ export class ImpulseFormList<
     })
   }
 
-  // TODO add tests
   public isValidated(scope: Scope): boolean
 
   public isValidated<TResult>(
@@ -437,7 +436,6 @@ export class ImpulseFormList<
     )
   }
 
-  // TODO add tests
   public setValidateOn(
     setter: ImpulseFormListValidateOnSetter<TElement>,
   ): void {

--- a/packages/react-impulse-form/src/ImpulseFormShape.ts
+++ b/packages/react-impulse-form/src/ImpulseFormShape.ts
@@ -191,7 +191,7 @@ export class ImpulseFormShape<
 
     for (const [key, field] of Object.entries(fields)) {
       acc[key as keyof TFields] = ImpulseForm.isImpulseForm(field)
-        ? (ImpulseForm._cloneWithParent(this, field) as TFields[keyof TFields])
+        ? (ImpulseForm._childOf(this, field) as TFields[keyof TFields])
         : (field as TFields[keyof TFields])
     }
 
@@ -245,10 +245,8 @@ export class ImpulseFormShape<
     return null
   }
 
-  protected _cloneWithParent(
-    root: null | ImpulseForm,
-  ): ImpulseFormShape<TFields> {
-    return new ImpulseFormShape(root, this.fields)
+  protected _childOf(parent: null | ImpulseForm): ImpulseFormShape<TFields> {
+    return new ImpulseFormShape(parent, this.fields)
   }
 
   protected _setValidated(isValidated: boolean): void {

--- a/packages/react-impulse-form/src/ImpulseFormShape.ts
+++ b/packages/react-impulse-form/src/ImpulseFormShape.ts
@@ -484,10 +484,10 @@ export class ImpulseFormShape<
     }
 
     return select(
-      touchedAll
-        ? true
-        : touchedNone
-          ? false
+      touchedNone
+        ? false
+        : touchedAll
+          ? true
           : (touchedConcise as unknown as ImpulseFormShapeFlagSchema<TFields>),
       touchedVerbose as unknown as ImpulseFormShapeFlagSchemaVerbose<TFields>,
     )

--- a/packages/react-impulse-form/src/ImpulseFormShape.ts
+++ b/packages/react-impulse-form/src/ImpulseFormShape.ts
@@ -191,10 +191,7 @@ export class ImpulseFormShape<
 
     for (const [key, field] of Object.entries(fields)) {
       acc[key as keyof TFields] = ImpulseForm.isImpulseForm(field)
-        ? (ImpulseForm._cloneWithRoot(
-            root ?? this,
-            field,
-          ) as TFields[keyof TFields])
+        ? (ImpulseForm._cloneWithParent(this, field) as TFields[keyof TFields])
         : (field as TFields[keyof TFields])
     }
 
@@ -248,7 +245,7 @@ export class ImpulseFormShape<
     return null
   }
 
-  protected _cloneWithRoot(
+  protected _cloneWithParent(
     root: null | ImpulseForm,
   ): ImpulseFormShape<TFields> {
     return new ImpulseFormShape(root, this.fields)

--- a/packages/react-impulse-form/src/ImpulseFormShape.ts
+++ b/packages/react-impulse-form/src/ImpulseFormShape.ts
@@ -369,10 +369,10 @@ export class ImpulseFormShape<
     }
 
     return select(
-      validatedAll
-        ? true
-        : validatedNone
-          ? false
+      validatedNone
+        ? false
+        : validatedAll
+          ? true
           : (validatedConcise as unknown as ImpulseFormShapeFlagSchema<TFields>),
       validatedVerbose as unknown as ImpulseFormShapeFlagSchemaVerbose<TFields>,
     )

--- a/packages/react-impulse-form/src/ImpulseFormShape.ts
+++ b/packages/react-impulse-form/src/ImpulseFormShape.ts
@@ -568,10 +568,10 @@ export class ImpulseFormShape<
     }
 
     return select(
-      touchedAll
-        ? true
-        : touchedNone
-          ? false
+      touchedNone
+        ? false
+        : touchedAll
+          ? true
           : (touchedConcise as unknown as ImpulseFormShapeFlagSchema<TFields>),
       touchedVerbose as unknown as ImpulseFormShapeFlagSchemaVerbose<TFields>,
     )

--- a/packages/react-impulse-form/src/ImpulseFormValue.ts
+++ b/packages/react-impulse-form/src/ImpulseFormValue.ts
@@ -242,11 +242,11 @@ export class ImpulseFormValue<
   }
 
   // TODO add tests against _validated when cloning
-  protected _cloneWithParent(
-    root: null | ImpulseForm,
+  protected _childOf(
+    parent: null | ImpulseForm,
   ): ImpulseFormValue<TOriginalValue, TValue> {
     return new ImpulseFormValue(
-      root,
+      parent,
       this._touched.clone(),
       this._validateOn.clone(),
       this._errors.clone(),

--- a/packages/react-impulse-form/src/ImpulseFormValue.ts
+++ b/packages/react-impulse-form/src/ImpulseFormValue.ts
@@ -242,7 +242,7 @@ export class ImpulseFormValue<
   }
 
   // TODO add tests against _validated when cloning
-  protected _cloneWithRoot(
+  protected _cloneWithParent(
     root: null | ImpulseForm,
   ): ImpulseFormValue<TOriginalValue, TValue> {
     return new ImpulseFormValue(

--- a/packages/react-impulse-form/src/dependencies.ts
+++ b/packages/react-impulse-form/src/dependencies.ts
@@ -17,5 +17,6 @@ export {
   isBoolean,
   isString,
   isTruthy,
+  isArray,
   identity,
 } from "remeda"

--- a/packages/react-impulse-form/src/index.ts
+++ b/packages/react-impulse-form/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./ImpulseForm"
-export * from "./ImpulseFormShape"
 export * from "./ImpulseFormValue"
+export * from "./ImpulseFormShape"
+export * from "./ImpulseFormList"
 export * from "./useImpulseForm"
 export * from "./useImpulseFormValue"
 export type { ValidateStrategy } from "./ValidateStrategy"

--- a/packages/react-impulse-form/src/utils.ts
+++ b/packages/react-impulse-form/src/utils.ts
@@ -17,6 +17,8 @@ export type ComputeObject<Obj> = unknown & {
 
 export const isTrue = (value: unknown): value is true => value === true
 
+export const isFalse = (value: unknown): value is false => value === false
+
 export const isHtmlElement = (value: unknown): value is HTMLElement => {
   return value instanceof HTMLElement
 }
@@ -39,6 +41,7 @@ export const uniq = <T>(values: ReadonlyArray<T>): ReadonlyArray<T> => {
   return result.length === values.length ? values : result
 }
 
+// TODO verify it is necessary
 export const forEach2 = <TLeft, TRight>(
   callback: (left: TLeft, right: TRight, index: number) => void,
   left: ReadonlyArray<TLeft>,

--- a/packages/react-impulse-form/src/utils.ts
+++ b/packages/react-impulse-form/src/utils.ts
@@ -41,19 +41,6 @@ export const uniq = <T>(values: ReadonlyArray<T>): ReadonlyArray<T> => {
   return result.length === values.length ? values : result
 }
 
-// TODO verify it is necessary
-export const forEach2 = <TLeft, TRight>(
-  callback: (left: TLeft, right: TRight, index: number) => void,
-  left: ReadonlyArray<TLeft>,
-  right: ReadonlyArray<TRight>,
-): void => {
-  const length = Math.min(left.length, right.length)
-
-  for (let index = 0; index < length; index++) {
-    callback(left[index]!, right[index]!, index)
-  }
-}
-
 export function shallowArrayEquals<T>(
   left: ReadonlyArray<T>,
   right: ReadonlyArray<T>,

--- a/packages/react-impulse-form/src/utils.ts
+++ b/packages/react-impulse-form/src/utils.ts
@@ -39,6 +39,18 @@ export const uniq = <T>(values: ReadonlyArray<T>): ReadonlyArray<T> => {
   return result.length === values.length ? values : result
 }
 
+export const forEach2 = <TLeft, TRight>(
+  callback: (left: TLeft, right: TRight, index: number) => void,
+  left: ReadonlyArray<TLeft>,
+  right: ReadonlyArray<TRight>,
+): void => {
+  const length = Math.min(left.length, right.length)
+
+  for (let index = 0; index < length; index++) {
+    callback(left[index]!, right[index]!, index)
+  }
+}
+
 export function shallowArrayEquals<T>(
   left: ReadonlyArray<T>,
   right: ReadonlyArray<T>,

--- a/packages/react-impulse-form/tests/ImpulseFormList.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormList.spec.ts
@@ -24,6 +24,19 @@ describe("ImpulseFormList#setElements()", () => {
     return ImpulseFormValue.of(initial, options)
   }
 
+  it("matches the type definition", () => {
+    const form = setup([setupElement(0)])
+
+    expectTypeOf(form.setElements).toEqualTypeOf<
+      (
+        setter: Setter<
+          ReadonlyArray<ImpulseFormValue<number>>,
+          [ReadonlyArray<ImpulseFormValue<number>>, Scope]
+        >,
+      ) => void
+    >()
+  })
+
   it("replaces all elements", ({ scope }) => {
     const form = setup([setupElement(0), setupElement(1), setupElement(2)])
 
@@ -31,10 +44,19 @@ describe("ImpulseFormList#setElements()", () => {
     expect(form.getOriginalValue(scope)).toStrictEqual([3, 4, 5])
   })
 
+  it("filters some elements", ({ scope }) => {
+    const form = setup([setupElement(0), setupElement(1), setupElement(2)])
+
+    form.setElements((elements, scope) => {
+      return elements.filter((element) => element.getOriginalValue(scope) > 1)
+    })
+    expect(form.getOriginalValue(scope)).toStrictEqual([2])
+  })
+
   it("modifies existing elements", ({ scope }) => {
     const form = setup([setupElement(0), setupElement(1), setupElement(2)])
 
-    form.setElements((current) => [...current, setupElement(3)])
+    form.setElements((elements) => [...elements, setupElement(3)])
     expect(form.getOriginalValue(scope)).toStrictEqual([0, 1, 2, 3])
   })
 

--- a/packages/react-impulse-form/tests/ImpulseFormList.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormList.spec.ts
@@ -140,8 +140,19 @@ describe("ImpulseFormList#setValidateOn()", () => {
 })
 
 describe("ImpulseFormList#isTouched()", () => {
+  const setup = (elements: ReadonlyArray<ImpulseFormValue<number>>) => {
+    return ImpulseFormList.of(elements)
+  }
+
+  const setupElement = (
+    initial: number,
+    options?: ImpulseFormValueOptions<number>,
+  ) => {
+    return ImpulseFormValue.of(initial, options)
+  }
+
   it("matches the type definition", ({ scope }) => {
-    const form = ImpulseFormList.of([ImpulseFormValue.of(0)])
+    const form = setup([setupElement(0)])
 
     expectTypeOf(form.isTouched).toEqualTypeOf<{
       (scope: Scope): boolean
@@ -164,6 +175,46 @@ describe("ImpulseFormList#isTouched()", () => {
       ): TResult
     }>()
   })
+
+  it("returns false for empty list", ({ scope }) => {
+    const form = setup([])
+
+    expect(form.isTouched(scope)).toBe(false)
+    expect(form.isTouched(scope, arg(0))).toBe(false)
+    expect(form.isTouched(scope, arg(1))).toStrictEqual([])
+  })
+
+  it("returns false when all elements are not touched", ({ scope }) => {
+    const form = setup([setupElement(0), setupElement(1), setupElement(2)])
+
+    expect(form.isTouched(scope)).toBe(false)
+    expect(form.isTouched(scope, arg(0))).toBe(false)
+    expect(form.isTouched(scope, arg(1))).toStrictEqual([false, false, false])
+  })
+
+  it("returns true when at least one element is touched", ({ scope }) => {
+    const form = setup([
+      setupElement(0),
+      setupElement(1),
+      setupElement(2, { touched: true }),
+    ])
+
+    expect(form.isTouched(scope)).toBe(true)
+    expect(form.isTouched(scope, arg(0))).toStrictEqual([false, false, true])
+    expect(form.isTouched(scope, arg(1))).toStrictEqual([false, false, true])
+  })
+
+  it("returns true when all elements are touched", ({ scope }) => {
+    const form = setup([
+      setupElement(0, { touched: true }),
+      setupElement(1, { touched: true }),
+      setupElement(2, { touched: true }),
+    ])
+
+    expect(form.isTouched(scope)).toBe(true)
+    expect(form.isTouched(scope, arg(0))).toBe(true)
+    expect(form.isTouched(scope, arg(1))).toStrictEqual([true, true, true])
+  })
 })
 
 describe("ImpulseFormList#setTouched()", () => {
@@ -182,6 +233,20 @@ describe("ImpulseFormList#setTouched()", () => {
     expectTypeOf(form.getElements(scope).at(0)!.setTouched).toEqualTypeOf<
       (setter: Setter<boolean>) => void
     >()
+  })
+
+  it("touches all items", ({ scope }) => {
+    const form = ImpulseFormList.of([
+      ImpulseFormValue.of(0),
+      ImpulseFormValue.of(1),
+      ImpulseFormValue.of(2),
+    ])
+
+    form.setTouched(true)
+    expect(form.isTouched(scope)).toBe(true)
+
+    form.setTouched(false)
+    expect(form.isTouched(scope)).toBe(false)
   })
 })
 

--- a/packages/react-impulse-form/tests/ImpulseFormList.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormList.spec.ts
@@ -206,6 +206,42 @@ describe("ImpulseFormList#reset()", () => {
       (resetter?: Setter<number, [number, number]>) => void
     >()
   })
+
+  it("sets initial values for all items", ({ scope }) => {
+    const form = ImpulseFormList.of([
+      ImpulseFormValue.of(0, { initialValue: 1 }),
+      ImpulseFormValue.of(1, { initialValue: 2 }),
+      ImpulseFormValue.of(2, { initialValue: 3 }),
+    ])
+
+    form.reset()
+    expect(form.getValue(scope)).toStrictEqual([1, 2, 3])
+  })
+
+  it("clears custom errors", ({ scope }) => {
+    const form = ImpulseFormList.of([
+      ImpulseFormValue.of(0, { errors: ["error"] }),
+      ImpulseFormValue.of(1, { errors: ["error"] }),
+      ImpulseFormValue.of(2, { errors: ["error"] }),
+    ])
+
+    form.reset()
+    expect(form.getErrors(scope)).toBeNull()
+  })
+
+  it("resets isValidated state", ({ scope }) => {
+    const form = ImpulseFormList.of([
+      ImpulseFormValue.of(0),
+      ImpulseFormValue.of(1),
+      ImpulseFormValue.of(2),
+    ])
+
+    form.setTouched(true)
+
+    expect(form.isValidated(scope)).toBe(true)
+    form.reset()
+    expect(form.isValidated(scope)).toBe(false)
+  })
 })
 
 describe("ImpulseFormList#isDirty()", () => {

--- a/packages/react-impulse-form/tests/ImpulseFormList.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormList.spec.ts
@@ -1,0 +1,338 @@
+import type { Scope } from "react-impulse"
+import { z } from "zod"
+
+import {
+  type ValidateStrategy,
+  type Setter,
+  ImpulseFormList,
+  ImpulseFormValue,
+} from "../src"
+
+describe("ImpulseFormList#getErrors()", () => {
+  it("matches the type definition", ({ scope }) => {
+    const form = ImpulseFormList.of([ImpulseFormValue.of(0)])
+
+    expectTypeOf(form.getErrors).toEqualTypeOf<{
+      (scope: Scope): null | ReadonlyArray<null | ReadonlyArray<string>>
+
+      <TResult>(
+        scope: Scope,
+        select: (
+          concise: null | ReadonlyArray<null | ReadonlyArray<string>>,
+          verbose: ReadonlyArray<null | ReadonlyArray<string>>,
+        ) => TResult,
+      ): TResult
+    }>()
+
+    expectTypeOf(form.getElements(scope).at(0)!.getErrors).toEqualTypeOf<{
+      (scope: Scope): null | ReadonlyArray<string>
+
+      <TResult>(
+        scope: Scope,
+        select: (
+          concise: null | ReadonlyArray<string>,
+          verbose: null | ReadonlyArray<string>,
+        ) => TResult,
+      ): TResult
+    }>()
+  })
+})
+
+describe("ImpulseFormList#setErrors()", () => {
+  it("matches the type definition", ({ scope }) => {
+    const form = ImpulseFormList.of([ImpulseFormValue.of(0)])
+
+    expectTypeOf(form.setErrors).toEqualTypeOf<
+      (
+        setter: Setter<
+          null | ReadonlyArray<
+            undefined | Setter<null | ReadonlyArray<string>>
+          >,
+          [ReadonlyArray<null | ReadonlyArray<string>>]
+        >,
+      ) => void
+    >()
+
+    expectTypeOf(form.getElements(scope).at(0)!.setErrors).toEqualTypeOf<
+      (setter: Setter<null | ReadonlyArray<string>>) => void
+    >()
+  })
+})
+
+describe("ImpulseFormList#isValidated()", () => {
+  it("matches the type definition", ({ scope }) => {
+    const form = ImpulseFormList.of([ImpulseFormValue.of(0)])
+
+    expectTypeOf(form.isValidated).toEqualTypeOf<{
+      (scope: Scope): boolean
+
+      <TResult>(
+        scope: Scope,
+        select: (
+          concise: boolean | ReadonlyArray<boolean>,
+          verbose: ReadonlyArray<boolean>,
+        ) => TResult,
+      ): TResult
+    }>()
+
+    expectTypeOf(form.getElements(scope).at(0)!.isValidated).toEqualTypeOf<{
+      (scope: Scope): boolean
+
+      <TResult>(
+        scope: Scope,
+        select: (concise: boolean, verbose: boolean) => TResult,
+      ): TResult
+    }>()
+  })
+})
+
+describe("ImpulseFormList#getValidateOn()", () => {
+  it("matches the type definition", ({ scope }) => {
+    const form = ImpulseFormList.of([ImpulseFormValue.of(0)])
+
+    expectTypeOf(form.getValidateOn).toEqualTypeOf<{
+      (scope: Scope): ValidateStrategy | ReadonlyArray<ValidateStrategy>
+
+      <TResult>(
+        scope: Scope,
+        select: (
+          concise: ValidateStrategy | ReadonlyArray<ValidateStrategy>,
+          verbose: ReadonlyArray<ValidateStrategy>,
+        ) => TResult,
+      ): TResult
+    }>()
+
+    expectTypeOf(form.getElements(scope).at(0)!.getValidateOn).toEqualTypeOf<{
+      (scope: Scope): ValidateStrategy
+
+      <TResult>(
+        scope: Scope,
+        select: (
+          concise: ValidateStrategy,
+          verbose: ValidateStrategy,
+        ) => TResult,
+      ): TResult
+    }>()
+  })
+})
+
+describe("ImpulseFormList#setValidateOn()", () => {
+  it("matches the type definition", ({ scope }) => {
+    const form = ImpulseFormList.of([ImpulseFormValue.of(0)])
+
+    expectTypeOf(form.setValidateOn).toEqualTypeOf<
+      (
+        setter: Setter<
+          | ValidateStrategy
+          | ReadonlyArray<undefined | Setter<ValidateStrategy>>,
+          [ReadonlyArray<ValidateStrategy>]
+        >,
+      ) => void
+    >()
+
+    expectTypeOf(form.getElements(scope).at(0)!.setValidateOn).toEqualTypeOf<
+      (setter: Setter<ValidateStrategy>) => void
+    >()
+  })
+})
+
+describe("ImpulseFormList#isTouched()", () => {
+  it("matches the type definition", ({ scope }) => {
+    const form = ImpulseFormList.of([ImpulseFormValue.of(0)])
+
+    expectTypeOf(form.isTouched).toEqualTypeOf<{
+      (scope: Scope): boolean
+
+      <TResult>(
+        scope: Scope,
+        select: (
+          concise: boolean | ReadonlyArray<boolean>,
+          verbose: ReadonlyArray<boolean>,
+        ) => TResult,
+      ): TResult
+    }>()
+
+    expectTypeOf(form.getElements(scope).at(0)!.isTouched).toEqualTypeOf<{
+      (scope: Scope): boolean
+
+      <TResult>(
+        scope: Scope,
+        select: (concise: boolean, verbose: boolean) => TResult,
+      ): TResult
+    }>()
+  })
+})
+
+describe("ImpulseFormList#setTouched()", () => {
+  it("matches the type definition", ({ scope }) => {
+    const form = ImpulseFormList.of([ImpulseFormValue.of(0)])
+
+    expectTypeOf(form.setTouched).toEqualTypeOf<
+      (
+        setter: Setter<
+          boolean | ReadonlyArray<undefined | Setter<boolean>>,
+          [ReadonlyArray<boolean>]
+        >,
+      ) => void
+    >()
+
+    expectTypeOf(form.getElements(scope).at(0)!.setTouched).toEqualTypeOf<
+      (setter: Setter<boolean>) => void
+    >()
+  })
+})
+
+describe("ImpulseFormList#reset()", () => {
+  it("matches the type definition", ({ scope }) => {
+    const form = ImpulseFormList.of([
+      ImpulseFormValue.of(0, {
+        schema: z.number().transform((x) => x.toFixed()),
+      }),
+    ])
+
+    expectTypeOf(form.reset).toEqualTypeOf<
+      (
+        resetter?: Setter<
+          ReadonlyArray<undefined | Setter<number, [number, number]>>,
+          [ReadonlyArray<number>, ReadonlyArray<number>]
+        >,
+      ) => void
+    >()
+
+    expectTypeOf(form.getElements(scope).at(0)!.reset).toEqualTypeOf<
+      (resetter?: Setter<number, [number, number]>) => void
+    >()
+  })
+})
+
+describe("ImpulseFormList#isDirty()", () => {
+  it("matches the type definition", ({ scope }) => {
+    const form = ImpulseFormList.of([ImpulseFormValue.of(0)])
+
+    expectTypeOf(form.isDirty).toEqualTypeOf<{
+      (scope: Scope): boolean
+
+      <TResult>(
+        scope: Scope,
+        select: (
+          concise: boolean | ReadonlyArray<boolean>,
+          verbose: ReadonlyArray<boolean>,
+        ) => TResult,
+      ): TResult
+    }>()
+
+    expectTypeOf(form.getElements(scope).at(0)!.isDirty).toEqualTypeOf<{
+      (scope: Scope): boolean
+
+      <TResult>(
+        scope: Scope,
+        select: (concise: boolean, verbose: boolean) => TResult,
+      ): TResult
+    }>()
+  })
+})
+
+describe("ImpulseFormList#getValue()", () => {
+  it("matches the type definition", ({ scope }) => {
+    const form = ImpulseFormList.of([
+      ImpulseFormValue.of(0, {
+        schema: z.number().transform((x) => x.toFixed()),
+      }),
+    ])
+
+    expectTypeOf(form.getValue).toEqualTypeOf<{
+      (scope: Scope): null | ReadonlyArray<string>
+
+      <TResult>(
+        scope: Scope,
+        select: (
+          concise: null | ReadonlyArray<string>,
+          verbose: ReadonlyArray<null | string>,
+        ) => TResult,
+      ): TResult
+    }>()
+
+    expectTypeOf(form.getElements(scope).at(0)!.getValue).toEqualTypeOf<{
+      (scope: Scope): null | string
+
+      <TResult>(
+        scope: Scope,
+        select: (concise: null | string, verbose: null | string) => TResult,
+      ): TResult
+    }>()
+  })
+})
+
+describe("ImpulseFormList#getOriginalValue()", () => {
+  it("matches the type definition", ({ scope }) => {
+    const form = ImpulseFormList.of([
+      ImpulseFormValue.of(0, {
+        schema: z.number().transform((x) => x.toFixed()),
+      }),
+    ])
+
+    expectTypeOf(form.getOriginalValue).toEqualTypeOf<
+      (scope: Scope) => ReadonlyArray<number>
+    >()
+
+    expectTypeOf(form.getElements(scope).at(0)!.getOriginalValue).toEqualTypeOf<
+      (scope: Scope) => number
+    >()
+  })
+})
+
+describe("ImpulseFormList#setOriginalValue()", () => {
+  it("matches the type definition", ({ scope }) => {
+    const form = ImpulseFormList.of([ImpulseFormValue.of(0)])
+
+    expectTypeOf(form.setOriginalValue).toEqualTypeOf<
+      (
+        setter: Setter<
+          ReadonlyArray<undefined | Setter<number>>,
+          [ReadonlyArray<number>]
+        >,
+      ) => void
+    >()
+
+    expectTypeOf(form.getElements(scope).at(0)!.setOriginalValue).toEqualTypeOf<
+      (setter: Setter<number>) => void
+    >()
+  })
+})
+
+describe("ImpulseFormList#getInitialValue()", () => {
+  it("matches the type definition", ({ scope }) => {
+    const form = ImpulseFormList.of([
+      ImpulseFormValue.of(0, {
+        schema: z.number().transform((x) => x.toFixed()),
+      }),
+    ])
+
+    expectTypeOf(form.getInitialValue).toEqualTypeOf<
+      (scope: Scope) => ReadonlyArray<number>
+    >()
+
+    expectTypeOf(form.getElements(scope).at(0)!.getInitialValue).toEqualTypeOf<
+      (scope: Scope) => number
+    >()
+  })
+})
+
+describe("ImpulseFormList#setInitialValue()", () => {
+  it("matches the type definition", ({ scope }) => {
+    const form = ImpulseFormList.of([ImpulseFormValue.of(0)])
+
+    expectTypeOf(form.setInitialValue).toEqualTypeOf<
+      (
+        setter: Setter<
+          ReadonlyArray<undefined | Setter<number>>,
+          [ReadonlyArray<number>]
+        >,
+      ) => void
+    >()
+
+    expectTypeOf(form.getElements(scope).at(0)!.setInitialValue).toEqualTypeOf<
+      (setter: Setter<number>) => void
+    >()
+  })
+})

--- a/packages/react-impulse-form/tests/ImpulseFormList.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormList.spec.ts
@@ -990,3 +990,63 @@ describe("ImpulseFormList#focusFirstInvalidValue()", () => {
     expect(listener_2).not.toHaveBeenCalled()
   })
 })
+
+describe("ImpulseFormList#onSubmit()", () => {
+  const setup = (
+    options?: ImpulseFormListOptions<ImpulseFormValue<number>>,
+  ) => {
+    const form = ImpulseFormList.of(
+      [ImpulseFormValue.of(1), ImpulseFormValue.of(2), ImpulseFormValue.of(3)],
+      options,
+    )
+
+    const listener_0 = vi.fn()
+    const listener_1 = vi.fn()
+    const listener_2 = vi.fn()
+    const listener_3 = vi.fn()
+
+    const elements = untrack((scope) => form.getElements(scope))
+
+    form.onSubmit(listener_0)
+    elements.at(0)?.onSubmit(listener_1)
+    elements.at(1)?.onSubmit(listener_2)
+    elements.at(2)?.onSubmit(listener_3)
+
+    return [
+      form,
+      {
+        listener_0,
+        listener_1,
+        listener_2,
+        listener_3,
+      },
+    ] as const
+  }
+
+  it("does not call the listeners on init", () => {
+    const [, { listener_0, listener_1, listener_2, listener_3 }] = setup()
+
+    expect(listener_0).not.toHaveBeenCalled()
+    expect(listener_1).not.toHaveBeenCalled()
+    expect(listener_2).not.toHaveBeenCalled()
+    expect(listener_3).not.toHaveBeenCalled()
+  })
+
+  it("provides values to the listeners", () => {
+    const [form, { listener_0, listener_1, listener_2, listener_3 }] = setup()
+
+    void form.submit()
+
+    expect(listener_0).toHaveBeenCalledOnce()
+    expect(listener_0).toHaveBeenLastCalledWith([1, 2, 3])
+
+    expect(listener_1).toHaveBeenCalledOnce()
+    expect(listener_1).toHaveBeenLastCalledWith(1)
+
+    expect(listener_2).toHaveBeenCalledOnce()
+    expect(listener_2).toHaveBeenLastCalledWith(2)
+
+    expect(listener_3).toHaveBeenCalledOnce()
+    expect(listener_3).toHaveBeenLastCalledWith(3)
+  })
+})

--- a/packages/react-impulse-form/tests/ImpulseFormList.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormList.spec.ts
@@ -12,6 +12,44 @@ import {
 
 import { arg } from "./common"
 
+describe("ImpulseFormList#setElements()", () => {
+  const setup = (elements: ReadonlyArray<ImpulseFormValue<number>>) => {
+    return ImpulseFormList.of(elements)
+  }
+
+  const setupElement = (
+    initial: number,
+    options?: ImpulseFormValueOptions<number>,
+  ) => {
+    return ImpulseFormValue.of(initial, options)
+  }
+
+  it("replaces all elements", ({ scope }) => {
+    const form = setup([setupElement(0), setupElement(1), setupElement(2)])
+
+    form.setElements([setupElement(3), setupElement(4), setupElement(5)])
+    expect(form.getOriginalValue(scope)).toStrictEqual([3, 4, 5])
+  })
+
+  it("modifies existing elements", ({ scope }) => {
+    const form = setup([setupElement(0), setupElement(1), setupElement(2)])
+
+    form.setElements((current) => [...current, setupElement(3)])
+    expect(form.getOriginalValue(scope)).toStrictEqual([0, 1, 2, 3])
+  })
+
+  it("attach the new elements to the form root", ({ scope }) => {
+    const form = setup([setupElement(0), setupElement(1), setupElement(2)])
+
+    form.setElements((current) => [...current, setupElement(3)])
+    void form.submit()
+
+    expect(form.getSubmitCount(scope)).toBe(1)
+    expect(form.getElements(scope).at(0)!.getSubmitCount(scope)).toBe(1)
+    expect(form.getElements(scope).at(3)!.getSubmitCount(scope)).toBe(1)
+  })
+})
+
 describe("ImpulseFormList#getErrors()", () => {
   const setup = (elements: ReadonlyArray<ImpulseFormValue<number>>) => {
     return ImpulseFormList.of(elements)
@@ -882,6 +920,15 @@ describe("ImpulseFormList#getInitialValue()", () => {
     ])
 
     expect(form.getInitialValue(scope)).toStrictEqual([3, 1, 4])
+  })
+
+  it("returns nested list's values", ({ scope }) => {
+    const form = ImpulseFormList.of([
+      ImpulseFormList.of([ImpulseFormValue.of(1)]),
+      ImpulseFormList.of([ImpulseFormValue.of(2), ImpulseFormValue.of(3)]),
+    ])
+
+    expect(form.getInitialValue(scope)).toStrictEqual([[1], [2, 3]])
   })
 })
 

--- a/packages/react-impulse-form/tests/ImpulseFormList.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormList.spec.ts
@@ -279,6 +279,22 @@ describe("ImpulseFormList#getOriginalValue()", () => {
       (scope: Scope) => number
     >()
   })
+
+  it("returns empty array for empty list", ({ scope }) => {
+    const form = ImpulseFormList.of([])
+
+    expect(form.getOriginalValue(scope)).toStrictEqual([])
+  })
+
+  it("returns an array of original values", ({ scope }) => {
+    const form = ImpulseFormList.of([
+      ImpulseFormValue.of(0),
+      ImpulseFormValue.of(1),
+      ImpulseFormValue.of(2),
+    ])
+
+    expect(form.getOriginalValue(scope)).toStrictEqual([0, 1, 2])
+  })
 })
 
 describe("ImpulseFormList#setOriginalValue()", () => {
@@ -298,6 +314,89 @@ describe("ImpulseFormList#setOriginalValue()", () => {
       (setter: Setter<number>) => void
     >()
   })
+
+  it("changes all items", ({ scope }) => {
+    const form = ImpulseFormList.of([
+      ImpulseFormValue.of(0),
+      ImpulseFormValue.of(1),
+      ImpulseFormValue.of(2),
+    ])
+
+    form.setOriginalValue([3, 4, 5])
+    expect(form.getOriginalValue(scope)).toStrictEqual([3, 4, 5])
+  })
+
+  it("changes nothing when setting an empty list", ({ scope }) => {
+    const form = ImpulseFormList.of([ImpulseFormValue.of(0)])
+
+    form.setOriginalValue([])
+    expect(form.getOriginalValue(scope)).toStrictEqual([0])
+  })
+
+  it("keeps the list empty", ({ scope }) => {
+    const form = ImpulseFormList.of<ImpulseFormValue<number>>([])
+
+    form.setOriginalValue([0, 1])
+    expect(form.getOriginalValue(scope)).toStrictEqual([])
+  })
+
+  it("changes only defined items", ({ scope }) => {
+    const form = ImpulseFormList.of([
+      ImpulseFormValue.of(0),
+      ImpulseFormValue.of(1),
+      ImpulseFormValue.of(2),
+    ])
+
+    form.setOriginalValue([3])
+    expect(form.getOriginalValue(scope)).toStrictEqual([3, 1, 2])
+
+    form.setOriginalValue([undefined, undefined, 4])
+    expect(form.getOriginalValue(scope)).toStrictEqual([3, 1, 4])
+  })
+
+  it("does not extend existing list", ({ scope }) => {
+    const form = ImpulseFormList.of([
+      ImpulseFormValue.of(0),
+      ImpulseFormValue.of(1),
+      ImpulseFormValue.of(2),
+    ])
+
+    form.setOriginalValue([3, 4, 5, 6])
+    expect(form.getOriginalValue(scope)).toStrictEqual([3, 4, 5])
+  })
+
+  it("passes the list in the transform function", ({ scope }) => {
+    const form = ImpulseFormList.of([
+      ImpulseFormValue.of(0),
+      ImpulseFormValue.of(1),
+      ImpulseFormValue.of(2),
+    ])
+
+    form.setOriginalValue((elements) => elements.map((x) => x + 1))
+    expect(form.getOriginalValue(scope)).toStrictEqual([1, 2, 3])
+  })
+
+  it("passes an element in the transform function", ({ scope }) => {
+    const form = ImpulseFormList.of([
+      ImpulseFormValue.of(0),
+      ImpulseFormValue.of(1),
+      ImpulseFormValue.of(2),
+    ])
+
+    form.setOriginalValue([undefined, (x) => x + 3])
+    expect(form.getOriginalValue(scope)).toStrictEqual([0, 4, 2])
+  })
+
+  it("passes an element in the list transform function", ({ scope }) => {
+    const form = ImpulseFormList.of([
+      ImpulseFormValue.of(0),
+      ImpulseFormValue.of(1),
+      ImpulseFormValue.of(2),
+    ])
+
+    form.setOriginalValue((elements) => elements.map(() => (x) => x + 1))
+    expect(form.getOriginalValue(scope)).toStrictEqual([1, 2, 3])
+  })
 })
 
 describe("ImpulseFormList#getInitialValue()", () => {
@@ -315,6 +414,22 @@ describe("ImpulseFormList#getInitialValue()", () => {
     expectTypeOf(form.getElements(scope).at(0)!.getInitialValue).toEqualTypeOf<
       (scope: Scope) => number
     >()
+  })
+
+  it("returns empty array for empty list", ({ scope }) => {
+    const form = ImpulseFormList.of([])
+
+    expect(form.getInitialValue(scope)).toStrictEqual([])
+  })
+
+  it("returns an array of original values", ({ scope }) => {
+    const form = ImpulseFormList.of([
+      ImpulseFormValue.of(0, { initialValue: 3 }),
+      ImpulseFormValue.of(1),
+      ImpulseFormValue.of(2, { initialValue: 4 }),
+    ])
+
+    expect(form.getInitialValue(scope)).toStrictEqual([3, 1, 4])
   })
 })
 
@@ -334,5 +449,16 @@ describe("ImpulseFormList#setInitialValue()", () => {
     expectTypeOf(form.getElements(scope).at(0)!.setInitialValue).toEqualTypeOf<
       (setter: Setter<number>) => void
     >()
+  })
+
+  it("changes all items", ({ scope }) => {
+    const form = ImpulseFormList.of([
+      ImpulseFormValue.of(0),
+      ImpulseFormValue.of(1),
+      ImpulseFormValue.of(2),
+    ])
+
+    form.setInitialValue([3, 4, 5])
+    expect(form.getInitialValue(scope)).toStrictEqual([3, 4, 5])
   })
 })

--- a/packages/react-impulse-form/tests/ImpulseFormShape.test.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormShape.test.ts
@@ -1291,6 +1291,20 @@ describe("ImpulseFormShape#isTouched()", () => {
     expect(isTouched).toBe(false)
     expectTypeOf(isTouched).toEqualTypeOf<boolean>()
   })
+
+  it("returns false for empty shape", ({ scope }) => {
+    const shape = ImpulseFormShape.of({})
+
+    expect(shape.isTouched(scope)).toBe(false)
+  })
+
+  it("returns false for shape without forms", ({ scope }) => {
+    const shape = ImpulseFormShape.of({
+      first: "one",
+    })
+
+    expect(shape.isTouched(scope)).toBe(false)
+  })
 })
 
 describe("ImpulseFormShape#setTouched()", () => {

--- a/packages/react-impulse-form/tests/ImpulseFormShape.test.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormShape.test.ts
@@ -9,10 +9,7 @@ import {
   ImpulseFormValue,
 } from "../src"
 
-const arg =
-  <TIndex extends number>(index: TIndex) =>
-  <TArgs extends ReadonlyArray<unknown>>(...args: TArgs): TArgs[TIndex] =>
-    args[index]
+import { arg } from "./common"
 
 describe("ImpulseFormShape.of()", () => {
   it("composes ImpulseFormShape from ImpulseFormValue", ({ scope }) => {

--- a/packages/react-impulse-form/tests/ImpulseFormShape.test.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormShape.test.ts
@@ -1980,6 +1980,20 @@ describe("ImpulseFormShape#isDirty()", () => {
     expect(isDirty).toBe(false)
     expectTypeOf(isDirty).toEqualTypeOf<boolean>()
   })
+
+  it("returns false for empty shape", ({ scope }) => {
+    const shape = ImpulseFormShape.of({})
+
+    expect(shape.isDirty(scope)).toBe(false)
+  })
+
+  it("returns false for shape without forms", ({ scope }) => {
+    const shape = ImpulseFormShape.of({
+      first: "one",
+    })
+
+    expect(shape.isDirty(scope)).toBe(false)
+  })
 })
 
 describe("ImpulseFormShape#reset()", () => {

--- a/packages/react-impulse-form/tests/ImpulseFormShape/isValidated.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormShape/isValidated.spec.ts
@@ -136,8 +136,8 @@ describe("isValidated(scope)", () => {
     expect(shape.fields.third.isValidated(scope)).toBe(true)
   })
 
-  it("returns true for empty shape", ({ scope }) => {
-    expect(ImpulseFormShape.of({}).isValidated(scope)).toBe(true)
+  it("returns false for empty shape", ({ scope }) => {
+    expect(ImpulseFormShape.of({}).isValidated(scope)).toBe(false)
   })
 })
 
@@ -196,8 +196,8 @@ describe("isValidated(scope, (concise) => concise)", () => {
     expect(isValidated(scope, shape.fields.third)).toBe(true)
   })
 
-  it("returns true for empty shape", ({ scope }) => {
-    expect(isValidated(scope, ImpulseFormShape.of({}))).toBe(true)
+  it("returns false for empty shape", ({ scope }) => {
+    expect(isValidated(scope, ImpulseFormShape.of({}))).toBe(false)
   })
 })
 

--- a/packages/react-impulse-form/tests/common.ts
+++ b/packages/react-impulse-form/tests/common.ts
@@ -1,3 +1,8 @@
 export async function wait(ms: number) {
   await new Promise((resolve) => setTimeout(resolve, ms))
 }
+
+export const arg =
+  <TIndex extends number>(index: TIndex) =>
+  <TArgs extends ReadonlyArray<unknown>>(...args: TArgs): TArgs[TIndex] =>
+    args[index]


### PR DESCRIPTION
Breaking changes:

- `ImpulseFormShape#isValidated`, `ImpulseFormShape#isDirty`, and `ImpulseFormShape#isTouched` return `false` for empty shapes.

Introduced:

- `ImpulseFormList` class.