### PR TITLE
Set `isTouched` to `false` when `reset`

### DIFF
--- a/.changeset/lucky-hairs-think.md
+++ b/.changeset/lucky-hairs-think.md
@@ -1,5 +1,5 @@
 ---
-"react-impulse-form": minor
+"react-impulse-form": patch
 ---
 
 Fixes:

--- a/.changeset/lucky-hairs-think.md
+++ b/.changeset/lucky-hairs-think.md
@@ -1,0 +1,8 @@
+---
+"react-impulse-form": minor
+---
+
+Fixes:
+
+- `ImpulseForm#isValid` returns true only when `ImpulseForm#isValidated` is true.
+- `ImpulseFormValue#reset` sets `ImpulseFormValue#isTouched` to false.

--- a/packages/react-impulse-form/src/ImpulseForm.ts
+++ b/packages/react-impulse-form/src/ImpulseForm.ts
@@ -144,12 +144,15 @@ export abstract class ImpulseForm<
     return this._childOf(null)
   }
 
+  // TODO add select
   public isValid(scope: Scope): boolean {
     return !this.isInvalid(scope)
   }
 
+  // TODO add select
+
   public isInvalid(scope: Scope): boolean {
-    return this.getErrors(scope, isDefined)
+    return this.isValidated(scope) && this.getErrors(scope, isDefined)
   }
 
   public abstract getErrors(scope: Scope): TParams["errors.schema"]

--- a/packages/react-impulse-form/src/ImpulseFormValue.ts
+++ b/packages/react-impulse-form/src/ImpulseFormValue.ts
@@ -386,9 +386,9 @@ export class ImpulseFormValue<
 
       this.setInitialValue(resetValue)
       this.setOriginalValue(resetValue)
-      // TODO test when reset
+      // TODO test when reset for all below
       this._validated.setValue(false)
-      // TODO test when reset
+      this._touched.setValue(false)
       this._errors.setValue([])
     })
   }


### PR DESCRIPTION

Fixes:

- `ImpulseForm#isValid` returns true only when `ImpulseForm#isValidated` is true.
- `ImpulseFormValue#reset` sets `ImpulseFormValue#isTouched` to false.