### PR TITLE
Introduce `ImpulseFormValueOptions.isInputDirty`

### DIFF
--- a/.changeset/honest-shirts-approve.md
+++ b/.changeset/honest-shirts-approve.md
@@ -1,0 +1,21 @@
+---
+"react-impulse-form": minor
+---
+
+Introduce `ImpulseFormValueOptions.isInputDirty` option:
+A compare function that determines whether the input is dirty. When it is, the `ImpulseFormValue#isDirty` returns `true`. Fallbacks to `not(isInputEqual)` if not provided.
+
+Useful for values that have intermediate states deviating from the initial value, but should not be considered dirty such as strings, unsorted arrays, etc. Intended to tune business logic and avoid false positives for dirty states.
+
+```ts
+const form = ImpulseFormValue.of("", {
+  isInputDirty: (left, right) => left.trim() !== right.trim(),
+})
+
+form.setInput(" ")
+form.isDirty(scope) === false
+```
+
+---
+
+Deletes `ImpulseFormValue#setCompare` option.

--- a/packages/react-impulse-form/src/ImpulseFormValue.ts
+++ b/packages/react-impulse-form/src/ImpulseFormValue.ts
@@ -38,6 +38,9 @@ export interface ImpulseFormValueOptions<TInput, TOutput = TInput> {
    * When it does, the ImpulseFormValue#getInput returns the new value.
    * Otherwise, it returns the previous value.
    *
+   * Useful for none primitive values such as Objects, Arrays, Date.
+   * Intended to improve performance but do not affect business logic.
+   *
    * @default Object.is
    *
    * @example
@@ -56,6 +59,10 @@ export interface ImpulseFormValueOptions<TInput, TOutput = TInput> {
    * A compare function that determines whether the input is dirty.
    * When it is, the ImpulseFormValue#isDirty returns true.
    * Fallbacks to not(isInputEqual) if not provided.
+   *
+   * Useful for values that have intermediate states deviating from the initial value,
+   * but should not be considered dirty such as strings, unsorted arrays, etc.
+   * Intended to tune business logic and avoid false positives for dirty states.
    *
    * @default not(isInputEqual)
    *

--- a/packages/react-impulse-form/tests/ImpulseFormValue/of.spec.ts
+++ b/packages/react-impulse-form/tests/ImpulseFormValue/of.spec.ts
@@ -1,0 +1,66 @@
+import { ImpulseFormValue } from "../../src"
+
+describe("ImpulseFormValueOptions.isInputDirty", () => {
+  it("uses Object.is when not provided", ({ scope }) => {
+    const value = ImpulseFormValue.of({ value: "value" })
+
+    expect(value.isDirty(scope)).toBe(false)
+
+    value.setInput({ value: "value" })
+    expect(value.isDirty(scope)).toBe(true)
+  })
+
+  it("fallbacks to isInputEqual when not provided", ({ scope }) => {
+    const value = ImpulseFormValue.of(
+      { value: "value" },
+      {
+        isInputEqual: (left, right) => left.value === right.value,
+      },
+    )
+
+    expect(value.isDirty(scope)).toBe(false)
+
+    value.setInput({ value: "value" })
+    expect(value.isDirty(scope)).toBe(false)
+  })
+
+  it("takes isInputDirty over isInputEqual", ({ scope }) => {
+    const value = ImpulseFormValue.of(
+      { value: "value" },
+      {
+        isInputEqual: (left, right) => left.value === right.value,
+        isInputDirty: (left, right) => left.value.trim() !== right.value.trim(),
+      },
+    )
+
+    expect(value.isDirty(scope)).toBe(false)
+
+    value.setInput({ value: "value " })
+    expect(value.isDirty(scope)).toBe(false)
+
+    value.setInput({ value: "value 1" })
+    expect(value.isDirty(scope)).toBe(true)
+  })
+
+  it("returns not dirty when isInputDirty returns false", ({ scope }) => {
+    const value = ImpulseFormValue.of("", {
+      isInputDirty: (left, right) => left.trim() !== right.trim(),
+    })
+
+    expect(value.isDirty(scope)).toBe(false)
+
+    value.setInput(" ")
+    expect(value.isDirty(scope)).toBe(false)
+  })
+
+  it("returns dirty when isInputDirty returns true", ({ scope }) => {
+    const value = ImpulseFormValue.of("", {
+      isInputDirty: (left, right) => left.trim() !== right.trim(),
+    })
+
+    expect(value.isDirty(scope)).toBe(false)
+
+    value.setInput(" s")
+    expect(value.isDirty(scope)).toBe(true)
+  })
+})


### PR DESCRIPTION
Resolves #747 

---

Introduce `ImpulseFormValueOptions.isInputDirty` option:
A compare function that determines whether the input is dirty. When it is, the `ImpulseFormValue#isDirty` returns `true`. Fallbacks to `not(isInputEqual)` if not provided.

Useful for values that have intermediate states deviating from the initial value, but should not be considered dirty such as strings, unsorted arrays, etc. Intended to tune business logic and avoid false positives for dirty states.

```ts
const form = ImpulseFormValue.of("", {
  isInputDirty: (left, right) => left.trim() !== right.trim(),
})

form.setInput(" ")
form.isDirty(scope) === false
```

---

Deletes `ImpulseFormValue#setCompare` option.