### PR TITLE
Extend `Impulse.of` with init callback

### DIFF
--- a/.changeset/weak-kiwis-count.md
+++ b/.changeset/weak-kiwis-count.md
@@ -1,0 +1,29 @@
+---
+"react-impulse": major
+---
+
+Extend `Impulse.of` to accept an init function similar to `useImpulse` signature:
+
+```dart
+of<T>(
+  valueOrInitValue: T | ((scope: Scope) => T),
+  options?: ImpulseOptions<T>,
+): Impulse<T>
+```
+
+- `[valueOrInitValue]` is an optional value used during the initial render. If the initial value infers from another Impulse, you may provide a function instead, which will be executed only during initialization. If not defined, the Impulse's value is `undefined` but it still can specify the value's type.
+- `[initialValue]` is an optional initial value. If not defined, the Impulse's value is `undefined` but it still can specify the value's type.
+- `[options]` is an optional [`ImpulseOptions`][impulse_options] object.
+  - `[options.compare]` when not defined or `null` then [`Object.is`][object_is] applies as a fallback.
+
+The **BREAKING CHANGE** is that all Impulses that store a function as a value, should wrap the initialization function with `Impulse.of` to avoid the function being executed during the initial render. Here is the migration guide:
+
+```ts
+// Before
+const sorting = Impulse.of((left: number, right: number) => left - right)
+
+// After
+const sorting = Impulse.of(() => {
+  return (left: number, right: number) => left - right
+})
+```

--- a/.changeset/weak-kiwis-count.md
+++ b/.changeset/weak-kiwis-count.md
@@ -2,7 +2,7 @@
 "react-impulse": major
 ---
 
-Extend `Impulse.of` to accept an init function similar to `useImpulse` signature:
+The `Impulse.of` signature has been extended to support initialization functions:
 
 ```dart
 of<T>(
@@ -11,12 +11,15 @@ of<T>(
 ): Impulse<T>
 ```
 
-- `[valueOrInitValue]` is an optional value used during the initial render. If the initial value infers from another Impulse, you may provide a function instead, which will be executed only during initialization. If not defined, the Impulse's value is `undefined` but it still can specify the value's type.
-- `[initialValue]` is an optional initial value. If not defined, the Impulse's value is `undefined` but it still can specify the value's type.
-- `[options]` is an optional [`ImpulseOptions`][impulse_options] object.
-  - `[options.compare]` when not defined or `null` then [`Object.is`][object_is] applies as a fallback.
+This allows for dynamic initialization based on other Impulse values:
 
-The **BREAKING CHANGE** is that all Impulses that store a function as a value, should wrap the initialization function with `Impulse.of` to avoid the function being executed during the initial render. Here is the migration guide:
+```ts
+// Initialize based on another Impulse
+const counter = Impulse.of(0)
+const isPositive = Impulse.of((scope) => counter.getValue(scope) > 0)
+```
+
+**BREAKING CHANGE**: If you're storing functions as values in Impulses, you must now wrap them with an initialization function to prevent them from being executed during initialization:
 
 ```ts
 // Before
@@ -27,3 +30,5 @@ const sorting = Impulse.of(() => {
   return (left: number, right: number) => left - right
 })
 ```
+
+This change improves the API's consistency and provides a more intuitive way to initialize Impulses with values derived from other sources.

--- a/packages/react-impulse/README.md
+++ b/packages/react-impulse/README.md
@@ -116,6 +116,7 @@ Impulse.of<T>(
 
 A static method that creates new Impulse.
 
+- `[valueOrInitValue]` is an optional value used during the initial render. If the initial value infers from another Impulse, you may provide a function instead, which will be executed only during initialization. If not defined, the Impulse's value is `undefined` but it still can specify the value's type.
 - `[initialValue]` is an optional initial value. If not defined, the Impulse's value is `undefined` but it still can specify the value's type.
 - `[options]` is an optional [`ImpulseOptions`][impulse_options] object.
   - `[options.compare]` when not defined or `null` then [`Object.is`][object_is] applies as a fallback.

--- a/packages/react-impulse/src/Impulse.ts
+++ b/packages/react-impulse/src/Impulse.ts
@@ -96,6 +96,10 @@ export abstract class Impulse<T> implements ImpulseGetter<T>, ImpulseSetter<T> {
    * Creates a new Impulse without an initial value.
    *
    * @version 1.2.0
+   *
+   * @example
+   * const answer = Impulse.of<string>()
+   * const initiallyUndefined = answer.getValue(scope) === undefined
    */
   public static of<T = undefined>(): Impulse<undefined | T>
 
@@ -109,6 +113,10 @@ export abstract class Impulse<T> implements ImpulseGetter<T>, ImpulseSetter<T> {
    * @param options.compare when not defined or `null` then `Object.is` applies as a fallback.
    *
    * @version 3.0.0
+   *
+   * @example
+   * const counter = Impulse.of(0)
+   * const isGreaterThanZero = Impulse.of(scope => counter.getValue(scope) > 0)
    */
   public static of<T>(
     valueOrInitValue: T | ((scope: Scope) => T),

--- a/packages/react-impulse/src/Impulse.ts
+++ b/packages/react-impulse/src/Impulse.ts
@@ -93,28 +93,36 @@ export abstract class Impulse<T> implements ImpulseGetter<T>, ImpulseSetter<T> {
   }
 
   /**
-   * Creates new Impulse without an initial value.
+   * Creates a new Impulse without an initial value.
    *
    * @version 1.2.0
    */
   public static of<T = undefined>(): Impulse<undefined | T>
 
   /**
-   * Creates new Impulse.
+   * Creates a new Impulse.
    *
-   * @param initialValue the initial value.
+   * *The init function is executed only once when the Impulse is created.*
+   *
+   * @param valueOrInitValue either an initial value or function returning an initial value during the initial render
    * @param options optional `ImpulseOptions`.
    * @param options.compare when not defined or `null` then `Object.is` applies as a fallback.
    *
-   * @version 1.0.0
+   * @version 3.0.0
    */
-  public static of<T>(initialValue: T, options?: ImpulseOptions<T>): Impulse<T>
+  public static of<T>(
+    valueOrInitValue: T | ((scope: Scope) => T),
+    options?: ImpulseOptions<T>,
+  ): Impulse<T>
 
   public static of<T>(
-    initialValue?: T,
+    initialValue?: T | ((scope: Scope) => T),
     options?: ImpulseOptions<undefined | T>,
   ): Impulse<undefined | T> {
-    return new DirectImpulse(initialValue, options?.compare ?? eq)
+    return new DirectImpulse(
+      isFunction(initialValue) ? initialValue(STATIC_SCOPE) : initialValue,
+      options?.compare ?? eq,
+    )
   }
 
   /**

--- a/packages/react-impulse/src/Impulse.ts
+++ b/packages/react-impulse/src/Impulse.ts
@@ -124,13 +124,14 @@ export abstract class Impulse<T> implements ImpulseGetter<T>, ImpulseSetter<T> {
   ): Impulse<T>
 
   public static of<T>(
-    initialValue?: T | ((scope: Scope) => T),
+    valueOrInitValue?: T | ((scope: Scope) => T),
     options?: ImpulseOptions<undefined | T>,
   ): Impulse<undefined | T> {
-    return new DirectImpulse(
-      isFunction(initialValue) ? initialValue(STATIC_SCOPE) : initialValue,
-      options?.compare ?? eq,
-    )
+    const value = isFunction(valueOrInitValue)
+      ? valueOrInitValue(STATIC_SCOPE)
+      : valueOrInitValue
+
+    return new DirectImpulse(value, options?.compare ?? eq)
   }
 
   /**

--- a/packages/react-impulse/tests/Impulse.spec.ts
+++ b/packages/react-impulse/tests/Impulse.spec.ts
@@ -86,6 +86,46 @@ describe("Impulse.of(value, options?)", () => {
   })
 })
 
+describe("Impulse.of(scope => value, options?)", () => {
+  it("passes static scope as the only argument", ({ scope }) => {
+    const init = vi.fn(() => 0)
+    const impulse = Impulse.of(init)
+
+    expect(init).toHaveBeenCalledExactlyOnceWith(scope)
+    expectTypeOf(impulse).toEqualTypeOf<Impulse<number>>()
+  })
+
+  it("creates impulse by using scope", ({ scope }) => {
+    const source = Impulse.of({ count: 0 })
+    const impulse = Impulse.of((scope) => source.getValue(scope))
+
+    expect(impulse.getValue(scope)).toStrictEqual({ count: 0 })
+    expect(impulse.getValue(scope)).toBe(source.getValue(scope))
+    expectTypeOf(impulse).toEqualTypeOf<Impulse<{ count: number }>>()
+  })
+
+  it("stores a function as value", ({ scope }) => {
+    const fn = () => ({ count: 0 })
+    const impulse = Impulse.of(() => fn)
+
+    expect(impulse.getValue(scope)).toBe(fn)
+    expect(impulse.getValue(scope)()).toStrictEqual({ count: 0 })
+    expectTypeOf(impulse).toEqualTypeOf<Impulse<() => { count: number }>>()
+  })
+
+  it("does not allow to specify init function with different arguments", ({
+    scope,
+  }) => {
+    const init = vi.fn((value: number) => value)
+    // @ts-expect-error should be (scope: Scope) => number
+    const impulse = Impulse.of(init)
+
+    expect(init).toHaveBeenCalledExactlyOnceWith(scope)
+    // just passes the scope
+    expect(impulse.getValue(scope)).toBe(scope)
+  })
+})
+
 describe("Impulse.transmit(getter, options?)", () => {
   it("creates a ReadonlyImpulse", () => {
     const impulse = Impulse.transmit(() => 0)


### PR DESCRIPTION
Resolves #660 

---
Extend `Impulse.of` to accept an init function similar to `useImpulse` signature:

```dart
of<T>(
  valueOrInitValue: T | ((scope: Scope) => T),
  options?: ImpulseOptions<T>,
): Impulse<T>
```

- `[valueOrInitValue]` is an optional value used during the initial render. If the initial value infers from another Impulse, you may provide a function instead, which will be executed only during initialization. If not defined, the Impulse's value is `undefined` but it still can specify the value's type.
- `[initialValue]` is an optional initial value. If not defined, the Impulse's value is `undefined` but it still can specify the value's type.
- `[options]` is an optional [`ImpulseOptions`][impulse_options] object.
  - `[options.compare]` when not defined or `null` then [`Object.is`][object_is] applies as a fallback.

The **BREAKING CHANGE** is that all Impulses that store a function as a value, should wrap the initialization function with `Impulse.of` to avoid the function being executed during the initial render. Here is the migration guide:

```ts
// Before
const sorting = Impulse.of((left: number, right: number) => left - right)

// After
const sorting = Impulse.of(() => {
  return (left: number, right: number) => left - right
})
```