### PR TITLE
Introduce `ImpulseGetter` and `ImpulseSetter` interfaces

### DIFF
--- a/.changeset/hip-suits-live.md
+++ b/.changeset/hip-suits-live.md
@@ -2,7 +2,7 @@
 "react-impulse": major
 ---
 
-**BREAKING CHANGE**
+**BREAKING CHANGES**
 
 The `Impulse#getValue` no longer supports the selector function as a second parameter. This change simplifies the API and makes behavior more predictable.
 

--- a/.changeset/hip-suits-live.md
+++ b/.changeset/hip-suits-live.md
@@ -1,0 +1,21 @@
+---
+"react-impulse": major
+---
+
+**BREAKING CHANGE**
+
+The `Impulse#getValue` no longer supports the selector function as a second parameter. This change simplifies the API and makes behavior more predictable.
+
+#### Migration Guide
+
+```ts
+// Before
+const count = Impulse.of(0)
+const doubled = count.getValue(scope, (value) => value * 2)
+
+// After
+const count = Impulse.of(0)
+const doubled = count.getValue(scope) * 2
+```
+
+Apply transformations directly to the returned value instead of passing a selector function.

--- a/.changeset/sad-shirts-turn.md
+++ b/.changeset/sad-shirts-turn.md
@@ -31,3 +31,15 @@ The following API has been adjusted to handle anything that implements the `Impu
 - ```dart
   function untrack<TValue>(impulse: ImpulseGetter<TValue>): TValue
   ```
+
+The **BREAKING CHANGE** is that the `Impulse#getValue` does not have the select API anymore. Here is the migration guide:
+
+```ts
+const impulse = Impulse.of(0)
+
+// Before
+const result = impulse.getValue(scope, (count) => count + 1)
+
+// After
+const result = impulse.getValue(scope) + 1
+```

--- a/.changeset/sad-shirts-turn.md
+++ b/.changeset/sad-shirts-turn.md
@@ -1,0 +1,29 @@
+---
+"react-impulse": minor
+---
+
+Introduce `ImpulseGetter` interface:
+
+```ts
+interface ImpulseGetter<T> {
+  getValue(scope: Scope): T
+}
+```
+
+The following API has been adjusted to handle anything that implements the `ImpulseGetter` rather than `Impulse`/`ReadonlyImpulse`:
+
+- ```dart
+  function useScoped<TValue>(impulse: ImpulseGetter<TValue>): TValue
+  ```
+
+- ```dart
+  Impulse.transmit<T>(
+    getter: ReadonlyImpulse<T> | ((scope: Scope) => T),
+    setter: Impulse<T> | ((value: T, scope: Scope) => void),
+    options?: TransmittingImpulseOptions<T>,
+  ): Impulse<T>
+  ```
+
+- ```dart
+  function untrack<TValue>(impulse: ImpulseGetter<TValue>): TValue
+  ```

--- a/.changeset/sad-shirts-turn.md
+++ b/.changeset/sad-shirts-turn.md
@@ -1,8 +1,8 @@
 ---
-"react-impulse": major
+"react-impulse": minor
 ---
 
-Introduce `ImpulseGetter` and `ImpulseSetter` interfaces:
+Added `ImpulseGetter` and `ImpulseSetter` Interfaces.
 
 ```ts
 interface ImpulseGetter<T> {
@@ -14,12 +14,11 @@ interface ImpulseSetter<T> {
 }
 ```
 
-The following API has been adjusted to handle anything that implements the `ImpulseGetter`/`ImpulseSetter` rather than `Impulse` OR `ReadonlyImpulse`:
+These interfaces allow more flexible usage patterns and third-party integrations. The following APIs now accept anything that implements these interfaces, not just Impulse instances:
 
 - ```dart
   function useScoped<TValue>(impulse: ImpulseGetter<TValue>): TValue
   ```
-
 - ```dart
   Impulse.transmit<T>(
     getter: ReadonlyImpulse<T> | ((scope: Scope) => T),
@@ -27,19 +26,8 @@ The following API has been adjusted to handle anything that implements the `Impu
     options?: TransmittingImpulseOptions<T>,
   ): Impulse<T>
   ```
-
 - ```dart
   function untrack<TValue>(impulse: ImpulseGetter<TValue>): TValue
   ```
 
-The **BREAKING CHANGE** is that the `Impulse#getValue` does not have the select API anymore. Here is the migration guide:
-
-```ts
-const impulse = Impulse.of(0)
-
-// Before
-const result = impulse.getValue(scope, (count) => count + 1)
-
-// After
-const result = impulse.getValue(scope) + 1
-```
+This change is backward compatible with all existing code while allowing for custom implementations of these interfaces.

--- a/.changeset/sad-shirts-turn.md
+++ b/.changeset/sad-shirts-turn.md
@@ -1,16 +1,20 @@
 ---
-"react-impulse": minor
+"react-impulse": major
 ---
 
-Introduce `ImpulseGetter` interface:
+Introduce `ImpulseGetter` and `ImpulseSetter` interfaces:
 
 ```ts
 interface ImpulseGetter<T> {
   getValue(scope: Scope): T
 }
+
+interface ImpulseSetter<T> {
+  setValue(value: T): void
+}
 ```
 
-The following API has been adjusted to handle anything that implements the `ImpulseGetter` rather than `Impulse`/`ReadonlyImpulse`:
+The following API has been adjusted to handle anything that implements the `ImpulseGetter`/`ImpulseSetter` rather than `Impulse` OR `ReadonlyImpulse`:
 
 - ```dart
   function useScoped<TValue>(impulse: ImpulseGetter<TValue>): TValue
@@ -19,7 +23,7 @@ The following API has been adjusted to handle anything that implements the `Impu
 - ```dart
   Impulse.transmit<T>(
     getter: ReadonlyImpulse<T> | ((scope: Scope) => T),
-    setter: Impulse<T> | ((value: T, scope: Scope) => void),
+    setter: ImpulseSetter<T> | ((value: T, scope: Scope) => void),
     options?: TransmittingImpulseOptions<T>,
   ): Impulse<T>
   ```

--- a/.changeset/stale-beds-smile.md
+++ b/.changeset/stale-beds-smile.md
@@ -1,0 +1,5 @@
+---
+"react-impulse-form": patch
+---
+
+Do not use `Impulse#getValue` with the select API anymore.

--- a/packages/react-impulse-form/src/ImpulseFormList.ts
+++ b/packages/react-impulse-form/src/ImpulseFormList.ts
@@ -343,7 +343,7 @@ export class ImpulseFormList<
       elements: ReadonlyArray<TElement>,
     ) => TResult = params._first as typeof select,
   ): TResult {
-    return this._elements.getValue(scope, select)
+    return select(this._elements.getValue(scope))
   }
 
   public setElements(

--- a/packages/react-impulse/README.md
+++ b/packages/react-impulse/README.md
@@ -101,7 +101,7 @@ A core piece of the library is the `Impulse` class - a box that holds value. The
 
 ### `Impulse`
 
-The impulse class. Extends [`ImpulseGetter`][impulse_getter] interface.
+The impulse class. Extends [`ImpulseGetter`][impulse_getter] and [`ImpulseSetter`][impulse_setter] interfaces.
 
 ### `Impulse.of`
 
@@ -135,13 +135,13 @@ Impulse.transmit<T>(
 
 Impulse.transmit<T>(
   getter: ImpulseGetter<T> | ((scope: Scope) => T),
-  setter: Impulse<T> | ((value: T, scope: Scope) => void),
+  setter: ImpulseSetter<T> | ((value: T, scope: Scope) => void),
   options?: TransmittingImpulseOptions<T>,
 ): Impulse<T>
 ```
 
-- `getter` is either anything that implements the `ImpulseGetter` interface or a function to read the transmitting value from the source.
-- `[setter]` either a destination impulse or is an optional function to write the transmitting value back to the source. When not defined, the Impulse is readonly.
+- `getter` is either anything that implements the [`ImpulseGetter`][impulse_getter] interface or a function to read the transmitting value from the source.
+- `[setter]` is either anything that implements the [`ImpulseSetter`][impulse_setter] interface or a function to write the transmitting value back to the source. or is an optional function to write the transmitting value back to the source. When not defined, the resulting Impulse is readonly.
 - `[options]` is an optional [`TransmittingImpulseOptions`][transmitting_impulse_options] object.
   - `[options.compare]` when not defined or `null` then [`Object.is`][object_is] applies as a fallback.
 
@@ -691,9 +691,13 @@ In the example above the `listener` will not react on the `impulse_2` updates un
 > // console: {"count":2}
 > ```
 
-### `type ImpulseGetter`
+### `interface ImpulseGetter`
 
 An interface that defines the `getValue` method.
+
+### `interface ImpulseSetter`
+
+An interface that defines the `setValue` method.
 
 ### `type ReadonlyImpulse`
 
@@ -808,7 +812,8 @@ Want to see ESLint suggestions for the dependencies? Add the hook name to the ES
 [batch]: #batch
 [untrack]: #untrack
 [subscribe]: #subscribe
-[impulse_getter]: #type-impulsegetter
+[impulse_getter]: #interface-impulsegetter
+[impulse_setter]: #interface-impulsesetter
 [impulse_options]: #interface-impulseoptions
 [transmitting_impulse_options]: #interface-transmittingimpulseoptions
 [use_scoped_options]: #interface-useScopedoptions

--- a/packages/react-impulse/README.md
+++ b/packages/react-impulse/README.md
@@ -377,7 +377,6 @@ A static method that checks whether the `input` is an `Impulse` instance. If the
 
 ```dart
 Impulse<T>#getValue(scope: Scope): T
-Impulse<T>#getValue<R>(scope: Scope, select: (value: T) => R): R
 ```
 
 An `Impulse` instance's method that returns the current value.
@@ -386,11 +385,10 @@ An `Impulse` instance's method that returns the current value.
 - `[select]` is an optional function that applies to the current value before returning.
 
 ```ts
-tap((scope) => {
-  const count = Impulse.of(3)
+const count = Impulse.of(3)
 
+tap((scope) => {
   count.getValue(scope) // === 3
-  count.getValue(scope, (x) => x > 0) // === true
 })
 ```
 

--- a/packages/react-impulse/README.md
+++ b/packages/react-impulse/README.md
@@ -141,7 +141,7 @@ Impulse.transmit<T>(
 ```
 
 - `getter` is either anything that implements the [`ImpulseGetter`][impulse_getter] interface or a function to read the transmitting value from the source.
-- `[setter]` is either anything that implements the [`ImpulseSetter`][impulse_setter] interface or a function to write the transmitting value back to the source. or is an optional function to write the transmitting value back to the source. When not defined, the resulting Impulse is readonly.
+- `[setter]` is either anything that implements the [`ImpulseSetter`][impulse_setter] interface or a function to write the transmitting value back to the source. When not defined, the resulting Impulse is readonly.
 - `[options]` is an optional [`TransmittingImpulseOptions`][transmitting_impulse_options] object.
   - `[options.compare]` when not defined or `null` then [`Object.is`][object_is] applies as a fallback.
 

--- a/packages/react-impulse/src/Impulse.ts
+++ b/packages/react-impulse/src/Impulse.ts
@@ -79,7 +79,13 @@ export abstract class Impulse<T> implements ImpulseGetter<T> {
       return isImpulse(args[0])
     }
 
-    return isImpulse(args[2]) && args[2].getValue(args[0], args[1])
+    if (isImpulse(args[2])) {
+      const value = args[2].getValue(args[0])
+
+      return args[1](value)
+    }
+
+    return false
   }
 
   /**
@@ -239,23 +245,10 @@ export abstract class Impulse<T> implements ImpulseGetter<T> {
    *
    * @version 1.0.0
    */
-  public getValue(scope: Scope): T
-  /**
-   * Returns a value selected from the impulse value.
-   *
-   * @param scope the Scope that tracks the Impulse value changes.
-   * @param select an optional function that applies to the impulse value before returning.
-   *
-   * @version 1.0.0
-   */
-  public getValue<R>(scope: Scope, select: (value: T, scope: Scope) => R): R
-
-  public getValue<R>(scope: Scope, select?: Func<[T, Scope], R>): T | R {
+  public getValue(scope: Scope): T {
     scope[EMITTER_KEY]?._attachTo(this._emitters)
 
-    const value = this._getter(scope)
-
-    return isFunction(select) ? select(value, scope) : value
+    return this._getter(scope)
   }
 
   /**

--- a/packages/react-impulse/src/Impulse.ts
+++ b/packages/react-impulse/src/Impulse.ts
@@ -19,13 +19,17 @@ export interface TransmittingImpulseOptions<T> {
 
 export type ReadonlyImpulse<T> = Omit<Impulse<T>, "setValue">
 
-const isImpulse = <T, Unknown = unknown>(
+export interface ImpulseGetter<T> {
+  getValue(scope: Scope): T
+}
+
+export function isImpulse<T, Unknown = unknown>(
   input: Unknown | Impulse<T>,
-): input is Impulse<T> => {
+): input is Impulse<T> {
   return input instanceof Impulse
 }
 
-export abstract class Impulse<T> {
+export abstract class Impulse<T> implements ImpulseGetter<T> {
   /**
    * A static method to check whether or not the input is an Impulse.
    *
@@ -122,7 +126,7 @@ export abstract class Impulse<T> {
    * Creates a new transmitting Impulse.
    * A transmitting Impulse is an Impulse that does not have its own value but reads it from the external source and writes it back.
    *
-   * @param getter either a source impulse or a function to read the transmitting value from the source.
+   * @param getter either anything that implements the `ImpulseGetter` interface or a function to read the transmitting value from the source.
    * @param setter either a destination impulse or a function to write the transmitting value back to the source.
    * @param options optional `TransmittingImpulseOptions`.
    * @param options.compare when not defined or `null` then `Object.is` applies as a fallback.
@@ -130,13 +134,13 @@ export abstract class Impulse<T> {
    * @version 2.0.0
    */
   public static transmit<T>(
-    getter: ReadonlyImpulse<T> | ((scope: Scope) => T),
+    getter: ImpulseGetter<T> | ((scope: Scope) => T),
     setter: Impulse<T> | ((value: T, scope: Scope) => void),
     options?: TransmittingImpulseOptions<T>,
   ): Impulse<T>
 
   public static transmit<T>(
-    getter: ReadonlyImpulse<T> | Func<[Scope], T>,
+    getter: ImpulseGetter<T> | Func<[Scope], T>,
     setterOrOptions?:
       | Impulse<T>
       | Func<[T, Scope]>

--- a/packages/react-impulse/src/index.ts
+++ b/packages/react-impulse/src/index.ts
@@ -5,6 +5,7 @@ export {
   type TransmittingImpulseOptions,
   type ReadonlyImpulse,
   type ImpulseGetter,
+  type ImpulseSetter,
   Impulse,
 } from "./Impulse"
 export type { Scope } from "./Scope"

--- a/packages/react-impulse/src/index.ts
+++ b/packages/react-impulse/src/index.ts
@@ -4,6 +4,7 @@ export {
   type ImpulseOptions,
   type TransmittingImpulseOptions,
   type ReadonlyImpulse,
+  type ImpulseGetter,
   Impulse,
 } from "./Impulse"
 export type { Scope } from "./Scope"

--- a/packages/react-impulse/src/untrack.ts
+++ b/packages/react-impulse/src/untrack.ts
@@ -1,4 +1,4 @@
-import type { ReadonlyImpulse } from "./Impulse"
+import type { ImpulseGetter } from "./Impulse"
 import { STATIC_SCOPE, type Scope } from "./Scope"
 import { ScopeEmitter } from "./ScopeEmitter"
 import { type Func, isFunction } from "./utils"
@@ -18,22 +18,22 @@ export function untrack<TResult>(factory: (scope: Scope) => TResult): TResult
 /**
  * Extracts the value from the provided `impulse` without tracking it.
  *
- * @param impulse an `Impulse` instance.
+ * @param impulse anything that implements the `ImpulseGetter` interface.
  *
  * @returns the `impulse` value.
  *
  * @version 2.0.0
  */
-export function untrack<TValue>(impulse: ReadonlyImpulse<TValue>): TValue
+export function untrack<TValue>(impulse: ImpulseGetter<TValue>): TValue
 
 export function untrack<T>(
-  factoryOrImpulse: ReadonlyImpulse<T> | Func<[Scope], T>,
+  factoryOrImpulseGetter: ImpulseGetter<T> | Func<[Scope], T>,
 ): T {
   return ScopeEmitter._schedule(() => {
-    if (isFunction(factoryOrImpulse)) {
-      return factoryOrImpulse(STATIC_SCOPE)
+    if (isFunction(factoryOrImpulseGetter)) {
+      return factoryOrImpulseGetter(STATIC_SCOPE)
     }
 
-    return factoryOrImpulse.getValue(STATIC_SCOPE)
+    return factoryOrImpulseGetter.getValue(STATIC_SCOPE)
   })
 }

--- a/packages/react-impulse/src/useScoped.ts
+++ b/packages/react-impulse/src/useScoped.ts
@@ -2,7 +2,7 @@ import { type DependencyList, useCallback, useDebugValue } from "./dependencies"
 import { type Compare, eq, useHandler, type Func, isFunction } from "./utils"
 import { STATIC_SCOPE, type Scope } from "./Scope"
 import { useCreateScope } from "./useCreateScope"
-import type { ReadonlyImpulse } from "./Impulse"
+import type { ImpulseGetter } from "./Impulse"
 
 export interface UseScopedOptions<T> {
   /**
@@ -19,11 +19,11 @@ export interface UseScopedOptions<T> {
  * A hook reads an `impulse` value whenever it updates
  * but enqueues a re-render only when the resulting value is different from the previous.
  *
- * @param impulse an impulse to extract scoped value from.
+ * @param impulse anything that implements the `ImpulseGetter` interface.
  *
  * @version 2.0.0
  */
-export function useScoped<TValue>(impulse: ReadonlyImpulse<TValue>): TValue
+export function useScoped<TValue>(impulse: ImpulseGetter<TValue>): TValue
 
 /**
  * A hook that executes the `factory` function whenever any of the involved Impulses' values update
@@ -42,20 +42,20 @@ export function useScoped<TResult>(
 ): TResult
 
 export function useScoped<TResult>(
-  impulseOrFactory: ReadonlyImpulse<TResult> | Func<[Scope], TResult>,
+  factoryOrImpulseGetter: ImpulseGetter<TResult> | Func<[Scope], TResult>,
   dependencies?: DependencyList,
   options?: UseScopedOptions<TResult>,
 ): TResult {
   const transform = useCallback(
     (scope: Scope) => {
-      if (isFunction(impulseOrFactory)) {
-        return impulseOrFactory(scope)
+      if (isFunction(factoryOrImpulseGetter)) {
+        return factoryOrImpulseGetter(scope)
       }
 
-      return impulseOrFactory.getValue(scope)
+      return factoryOrImpulseGetter.getValue(scope)
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    dependencies ?? [impulseOrFactory],
+    dependencies ?? [factoryOrImpulseGetter],
   )
   const value = useCreateScope(
     transform,

--- a/packages/react-impulse/tests/Impulse.spec.ts
+++ b/packages/react-impulse/tests/Impulse.spec.ts
@@ -704,25 +704,6 @@ describe.each([
     })
   })
 
-  describe("Impulse#getValue(transform)", () => {
-    it("gets initial value", ({ scope }) => {
-      const initial = { count: 0 }
-      const { impulse } = setup(initial)
-
-      expect(impulse.getValue(scope)).toBe(initial)
-      expect(impulse.getValue(scope, Counter.getCount)).toBe(0)
-    })
-
-    it("gets updates value", ({ scope }) => {
-      const initial = { count: 0 }
-      const { impulse } = setup(initial)
-
-      impulse.setValue(Counter.inc)
-      expect(impulse.getValue(scope)).toStrictEqual({ count: 1 })
-      expect(impulse.getValue(scope, Counter.getCount)).toBe(1)
-    })
-  })
-
   describe("Impulse#clone()", () => {
     it("creates new Impulse", ({ scope }) => {
       const { impulse: impulse_1 } = setup({ count: 0 })
@@ -896,17 +877,13 @@ describe.each([
       expect(impulse_1.getValue(scope).name).not.toBe(
         impulse_2.getValue(scope).name,
       )
-      expect(
-        impulse_1.getValue(scope, ({ count, name }, scope) => ({
-          count: count.getValue(scope),
-          name: name.getValue(scope),
-        })),
-      ).toStrictEqual(
-        impulse_2.getValue(scope, ({ count, name }, scope) => ({
-          count: count.getValue(scope),
-          name: name.getValue(scope),
-        })),
-      )
+      expect({
+        count: impulse_1.getValue(scope).count.getValue(scope),
+        name: impulse_1.getValue(scope).name.getValue(scope),
+      }).toStrictEqual({
+        count: impulse_2.getValue(scope).count.getValue(scope),
+        name: impulse_2.getValue(scope).name.getValue(scope),
+      })
 
       // the nested impulses are independent
       impulse_1.getValue(scope).count.setValue(1)
@@ -933,17 +910,13 @@ describe.each([
       expect(impulse_1.getValue(scope).name).toBe(
         impulse_2.getValue(scope).name,
       )
-      expect(
-        impulse_1.getValue(scope, ({ count, name }) => ({
-          count: count.getValue(scope),
-          name: name.getValue(scope),
-        })),
-      ).toStrictEqual(
-        impulse_2.getValue(scope, ({ count, name }) => ({
-          count: count.getValue(scope),
-          name: name.getValue(scope),
-        })),
-      )
+      expect({
+        count: impulse_1.getValue(scope).count.getValue(scope),
+        name: impulse_1.getValue(scope).name.getValue(scope),
+      }).toStrictEqual({
+        count: impulse_1.getValue(scope).count.getValue(scope),
+        name: impulse_1.getValue(scope).name.getValue(scope),
+      })
 
       // the nested impulses are dependent
       impulse_1.getValue(scope).count.setValue(1)

--- a/packages/react-impulse/tests/hooks-in-components/batch.spec.tsx
+++ b/packages/react-impulse/tests/hooks-in-components/batch.spec.tsx
@@ -258,8 +258,8 @@ describe.each([
           spy()
 
           return (
-            first.getValue(scope, Counter.getCount) +
-            second.getValue(scope, Counter.getCount)
+            Counter.getCount(first.getValue(scope)) +
+            Counter.getCount(second.getValue(scope))
           )
         }
 
@@ -346,12 +346,12 @@ describe.each([
         const factory = (scope: Scope) => {
           spy()
 
-          return impulse.getValue(scope, ({ first, second }, scope) => {
-            return (
-              first.getValue(scope, Counter.getCount) +
-              second.getValue(scope, Counter.getCount)
-            )
-          })
+          const { first, second } = impulse.getValue(scope)
+
+          return (
+            Counter.getCount(first.getValue(scope)) +
+            Counter.getCount(second.getValue(scope))
+          )
         }
 
         return { spy, onRender, impulse, factory }

--- a/packages/react-impulse/tests/hooks-in-components/untrack.spec.tsx
+++ b/packages/react-impulse/tests/hooks-in-components/untrack.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { fireEvent, render, screen } from "@testing-library/react"
 
-import { Impulse, untrack } from "../../src"
+import { Impulse, untrack, type ImpulseGetter } from "../../src"
 
 it("returns the `factory` function result without tracking impulses", () => {
   const onRender = vi.fn()
@@ -54,10 +54,34 @@ it("returns the `factory` function result without tracking impulses", () => {
   expect(onRender).toHaveBeenCalledTimes(1)
 })
 
+it("allows to use Impulse", () => {
+  const impulse = Impulse.of(1)
+
+  const value = untrack(impulse)
+
+  expect(value).toBe(1)
+})
+
 it("allows to use ReadonlyImpulse", () => {
   const impulse = Impulse.transmit(() => 1)
 
   const value = untrack(impulse)
 
   expect(value).toBe(1)
+})
+
+it("allows to use ImpulseGetter", () => {
+  class Custom implements ImpulseGetter<number> {
+    public constructor(public value: number) {}
+
+    public getValue(): number {
+      return this.value
+    }
+  }
+
+  const impulse = new Custom(1)
+
+  expect(untrack(impulse)).toBe(1)
+  impulse.value = 2
+  expect(untrack(impulse)).toBe(2)
 })

--- a/packages/react-impulse/tests/subscribe.spec.ts
+++ b/packages/react-impulse/tests/subscribe.spec.ts
@@ -442,12 +442,9 @@ describe("nested Impulses", () => {
     })
 
     subscribe((scope) => {
-      spy(
-        impulse_3.getValue(
-          scope,
-          ({ first, second }) => first.getValue(scope) + second.getValue(scope),
-        ),
-      )
+      const { first, second } = impulse_3.getValue(scope)
+
+      spy(first.getValue(scope) + second.getValue(scope))
     })
 
     expect(impulse_1).toHaveEmittersSize(1)
@@ -467,12 +464,9 @@ describe("nested Impulses", () => {
     })
 
     subscribe((scope) => {
-      spy(
-        impulse_3.getValue(
-          scope,
-          ({ first, second }) => first.getValue(scope) + second.getValue(scope),
-        ),
-      )
+      const { first, second } = impulse_3.getValue(scope)
+
+      spy(first.getValue(scope) + second.getValue(scope))
     })
 
     spy.mockReset()

--- a/packages/react-impulse/tests/useScoped/single-impulse.spec.ts
+++ b/packages/react-impulse/tests/useScoped/single-impulse.spec.ts
@@ -182,8 +182,9 @@ describe("transform scoped Impulse's", () => {
     return prevLeft === nextLeft && prevRight === nextRight
   }
 
-  const factoryTuple = (scope: Scope, { impulse }: WithImpulse) =>
-    impulse.getValue(scope, toTuple)
+  const factoryTuple = (scope: Scope, { impulse }: WithImpulse) => {
+    return toTuple(impulse.getValue(scope))
+  }
 
   it.each([
     [

--- a/packages/react-impulse/tests/useScoped/single-impulse.spec.ts
+++ b/packages/react-impulse/tests/useScoped/single-impulse.spec.ts
@@ -1,14 +1,55 @@
 import { act, renderHook } from "@testing-library/react"
 
-import { type Compare, Impulse, useScoped, type Scope } from "../../src"
+import {
+  type Compare,
+  Impulse,
+  useScoped,
+  type Scope,
+  type ImpulseGetter,
+} from "../../src"
 import { Counter, type WithSpy, type WithImpulse } from "../common"
 
 describe("impulse shortcut", () => {
-  it("allows to use ReadonlyImpulse", () => {
-    const impulse = Impulse.transmit(() => 1)
+  it("allows to use Impulse", () => {
+    const impulse = Impulse.of(1)
 
     const { result } = renderHook(() => useScoped(impulse))
 
+    expect(result.current).toBe(1)
+  })
+
+  it("allows to use ReadonlyImpulse", () => {
+    let count = 1
+    const impulse = Impulse.transmit(() => count)
+
+    const { result, rerender } = renderHook(() => useScoped(impulse))
+
+    expect(result.current).toBe(1)
+    count = 2
+    expect(result.current).toBe(1)
+
+    rerender()
+    expect(result.current).toBe(1)
+  })
+
+  it("allows to use ImpulseGetter", () => {
+    class Custom implements ImpulseGetter<number> {
+      public constructor(public value: number) {}
+
+      public getValue(): number {
+        return this.value
+      }
+    }
+
+    const impulse = new Custom(1)
+
+    const { result, rerender } = renderHook(() => useScoped(impulse))
+
+    expect(result.current).toBe(1)
+    impulse.value = 2
+    expect(result.current).toBe(1)
+
+    rerender()
     expect(result.current).toBe(1)
   })
 


### PR DESCRIPTION
Resolves #719 

---

# `react-impulse`

## MINOR CHANGES


Added `ImpulseGetter` and `ImpulseSetter` Interfaces.

```ts
interface ImpulseGetter<T> {
  getValue(scope: Scope): T
}

interface ImpulseSetter<T> {
  setValue(value: T): void
}
```

These interfaces allow more flexible usage patterns and third-party integrations. The following APIs now accept anything that implements these interfaces, not just Impulse instances:

- ```dart
  function useScoped<TValue>(impulse: ImpulseGetter<TValue>): TValue
  ```
- ```dart
  Impulse.transmit<T>(
    getter: ReadonlyImpulse<T> | ((scope: Scope) => T),
    setter: ImpulseSetter<T> | ((value: T, scope: Scope) => void),
    options?: TransmittingImpulseOptions<T>,
  ): Impulse<T>
  ```
- ```dart
  function untrack<TValue>(impulse: ImpulseGetter<TValue>): TValue
  ```

This change is backward compatible with all existing code while allowing for custom implementations of these interfaces.


---

## **BREAKING CHANGES**

The `Impulse#getValue` no longer supports the selector function as a second parameter. This change simplifies the API and makes behavior more predictable.

#### Migration Guide

```ts
// Before
const count = Impulse.of(0)
const doubled = count.getValue(scope, (value) => value * 2)

// After
const count = Impulse.of(0)
const doubled = count.getValue(scope) * 2
```

Apply transformations directly to the returned value instead of passing a selector function.

# `react-impulse-form`

## MINOR CHANGES


Do not use `Impulse#getValue` with the select API anymore.

