### PR TITLE
Simplify inner hooks

### DIFF
--- a/.changeset/red-walls-change.md
+++ b/.changeset/red-walls-change.md
@@ -1,0 +1,5 @@
+---
+"react-impulse": patch
+---
+
+Simplified the internal `usePermanent` and `useHandler` hooks by utilizing `useRef` for better performance and reduced complexity.

--- a/packages/react-impulse/src/useScoped.ts
+++ b/packages/react-impulse/src/useScoped.ts
@@ -57,14 +57,13 @@ export function useScoped<TResult>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
     dependencies ?? [factoryOrImpulseGetter],
   )
-  const value = useCreateScope(
-    transform,
-    useHandler((prev, next) => {
-      const compare = options?.compare ?? eq
+  const compare = useHandler((prev: TResult, next: TResult) => {
+    const cmp = options?.compare ?? eq
 
-      return compare(prev, next, STATIC_SCOPE)
-    }),
-  )
+    return cmp(prev, next, STATIC_SCOPE)
+  })
+
+  const value = useCreateScope(transform, compare)
 
   useDebugValue(value)
 

--- a/packages/react-impulse/src/useScoped.ts
+++ b/packages/react-impulse/src/useScoped.ts
@@ -57,13 +57,15 @@ export function useScoped<TResult>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
     dependencies ?? [factoryOrImpulseGetter],
   )
-  const compare = useHandler((prev: TResult, next: TResult) => {
-    const cmp = options?.compare ?? eq
 
-    return cmp(prev, next, STATIC_SCOPE)
-  })
+  const value = useCreateScope(
+    transform,
+    useHandler((prev, next) => {
+      const compare = options?.compare ?? eq
 
-  const value = useCreateScope(transform, compare)
+      return compare(prev, next, STATIC_SCOPE)
+    }),
+  )
 
   useDebugValue(value)
 

--- a/packages/react-impulse/src/utils.ts
+++ b/packages/react-impulse/src/utils.ts
@@ -33,7 +33,7 @@ export function isFunction<
 }
 
 export function useHandler<TArgs extends ReadonlyArray<unknown>, TResult>(
-  value: Func<TArgs, TResult>,
+  handler: Func<TArgs, TResult>,
 ): Func<TArgs, TResult> {
   /**
    * Despise React official documentation pointing out:
@@ -53,11 +53,11 @@ export function useHandler<TArgs extends ReadonlyArray<unknown>, TResult>(
    */
 
   const ref = useRef({
-    _value: value,
+    _value: handler,
     _getter: (...args: TArgs) => ref.current._value(...args),
   })
 
-  ref.current._value = value
+  ref.current._value = handler
 
   return ref.current._getter
 }


### PR DESCRIPTION
Resolved #804 

---


Simplified the internal `usePermanent` and `useHandler` hooks by utilizing `useRef` for better performance and reduced complexity.