### PR TITLE
Drop repository_owner from release `if` statement.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,8 +166,8 @@ jobs:
     name: Release on npm
     runs-on: ubuntu-latest
     needs: [checks, test-dist, test-react-support, test-react-impulse-support]
-    # prevents this action from running on forks and only on pushes
-    if: ${{ github.repository_owner == 'owanturist' && github.event_name == 'push' }}
+    # run only on pushes (not PRs)
+    if: ${{ github.event_name == 'push' }}
     concurrency: ${{ github.workflow }}-${{ github.ref }}
 
     steps:


### PR DESCRIPTION
For some reason, the release job does not trigger anymore. Maybe the reason is in the `github.repository_owner == 'owanturist'` check.