### PR TITLE
Return output when valid but not validated

### DIFF
--- a/.changeset/petite-dragons-mix.md
+++ b/.changeset/petite-dragons-mix.md
@@ -1,0 +1,7 @@
+---
+"react-impulse-form": minor
+---
+
+**BREAKING CHANGES**
+
+The `ImpulseFormUnit#getOutput` returns the output value even when the unit is **not validated**. It used to return `[null, null]` in such cases.

--- a/packages/react-impulse-form/src/impulse-form-unit/_impulse-form-unit.ts
+++ b/packages/react-impulse-form/src/impulse-form-unit/_impulse-form-unit.ts
@@ -123,11 +123,17 @@ export class ImpulseFormUnit<
       return [null, input as unknown as TOutput]
     }
 
-    if (!this._validated.getValue(scope)) {
-      return [null, null]
+    const [error, output] = validator._validate(this.getInput(scope))
+
+    if (isNull(error)) {
+      return [null, output]
     }
 
-    return validator._validate(this.getInput(scope))
+    if (this._validated.getValue(scope)) {
+      return [error, null]
+    }
+
+    return [null, null]
   }
 
   protected _getFocusFirstInvalidValue(): null | VoidFunction {

--- a/packages/react-impulse-form/tests/impulse-form-unit.spec.ts
+++ b/packages/react-impulse-form/tests/impulse-form-unit.spec.ts
@@ -217,12 +217,12 @@ describe("ImpulseFormUnit()", () => {
 })
 
 describe("ImpulseFormUnit#getOutput()", () => {
-  it("does not select value when not validated", ({ scope }) => {
+  it("selects value when not validated", ({ scope }) => {
     const value = ImpulseFormUnit("1", {
       schema: z.string().max(1),
     })
 
-    expect(value.getOutput(scope)).toBeNull()
+    expect(value.getOutput(scope)).toBe("1")
     expect(value.getError(scope)).toBeNull()
 
     value.setTouched(true)

--- a/packages/react-impulse-form/tests/impulse-form-unit/focus-firstInvalid.spec.ts
+++ b/packages/react-impulse-form/tests/impulse-form-unit/focus-firstInvalid.spec.ts
@@ -157,6 +157,7 @@ describe("focusFirstInvalid() when not validated", () => {
     const listener = vi.fn()
 
     form.onFocusWhenInvalid(listener)
+    form.focusFirstInvalid()
 
     expect(listener).not.toHaveBeenCalled()
   })
@@ -168,6 +169,7 @@ describe("focusFirstInvalid() when valid", () => {
     const listener = vi.fn()
 
     form.onFocusWhenInvalid(listener)
+    form.focusFirstInvalid()
 
     expect(listener).not.toHaveBeenCalled()
   })


### PR DESCRIPTION

**BREAKING CHANGES**

The `ImpulseFormUnit#getOutput` returns the output value even when the unit is **not validated**. It used to return `[null, null]` in such cases.