### PR TITLE
Respect `validateOn=onInit` when `ImpulseForm#reset()`

### DIFF
--- a/.changeset/proud-facts-cheat.md
+++ b/.changeset/proud-facts-cheat.md
@@ -1,0 +1,5 @@
+---
+"react-impulse-form": patch
+---
+
+Calling `ImpulseForm#reset()` updates the `isValidated` state according the `validateOn` strategy. Resolves [#797](https://github.com/owanturist/react-impulse/issues/797).

--- a/packages/react-impulse-form/src/impulse-form-unit/_impulse-form-unit.ts
+++ b/packages/react-impulse-form/src/impulse-form-unit/_impulse-form-unit.ts
@@ -320,9 +320,9 @@ export class ImpulseFormUnit<
       this.setInitial(resetValue)
       this.setInput(resetValue)
       // TODO test when reset for all below
-      this._validated.setValue(false)
       this._touched.setValue(false)
       this._errors.setValue(null)
+      this._updateValidated(true)
     })
   }
 

--- a/packages/react-impulse-form/tests/impulse-form-list/reset.spec.ts
+++ b/packages/react-impulse-form/tests/impulse-form-list/reset.spec.ts
@@ -54,14 +54,14 @@ it("clears custom errors", ({ scope }) => {
 
 it("resets isValidated state", ({ scope }) => {
   const form = ImpulseFormList([
-    ImpulseFormUnit(0),
-    ImpulseFormUnit(1),
-    ImpulseFormUnit(2),
+    ImpulseFormUnit(0, { schema: z.number() }),
+    ImpulseFormUnit(1, { schema: z.number() }),
+    ImpulseFormUnit(2, { schema: z.number() }),
   ])
 
   form.setTouched(true)
-
   expect(form.isValidated(scope)).toBe(true)
+
   form.reset()
   expect(form.isValidated(scope)).toBe(false)
 })

--- a/packages/react-impulse-form/tests/impulse-form-unit/reset.spec.ts
+++ b/packages/react-impulse-form/tests/impulse-form-unit/reset.spec.ts
@@ -4,61 +4,144 @@ import { params } from "~/tools/params"
 
 import { type ImpulseForm, ImpulseFormUnit } from "../../src"
 
-describe("ImpulseFormUnit#reset()", () => {
-  describe.each([
-    ["without arguments", (form: ImpulseForm) => form.reset()],
-    [
-      "with resetter=identity",
-      (form: ImpulseForm) => form.reset(params._first),
-    ],
-  ])("%s", (_, reset) => {
-    it("resets to initial value", ({ scope }) => {
-      const value = ImpulseFormUnit("", { initial: "1" })
+it("resets to initial value", ({ scope }) => {
+  const unit = ImpulseFormUnit("")
 
-      reset(value)
-      expect(value.getInput(scope)).toBe("1")
-      expect(value.getInitial(scope)).toBe("1")
-      expect(value.isDirty(scope)).toBe(false)
-    })
+  unit.setInput("1")
+  expect(unit.getInput(scope)).toBe("1")
+
+  unit.reset()
+  expect(unit.getInput(scope)).toBe("")
+})
+
+describe.each([
+  ["without arguments", (form: ImpulseForm) => form.reset()],
+  ["with resetter=identity", (form: ImpulseForm) => form.reset(params._first)],
+])("%s", (_, reset) => {
+  it("resets to custom initial value", ({ scope }) => {
+    const unit = ImpulseFormUnit("", { initial: "1" })
+
+    reset(unit)
+    expect(unit.getInput(scope)).toBe("1")
+    expect(unit.getInitial(scope)).toBe("1")
+    expect(unit.isDirty(scope)).toBe(false)
+  })
+})
+
+it("resets to initial value by consuming current original value with resetter", ({
+  scope,
+}) => {
+  const unit = ImpulseFormUnit("2", { initial: "1" })
+
+  unit.reset((_, current) => current)
+  expect(unit.getInput(scope)).toBe("2")
+  expect(unit.getInitial(scope)).toBe("2")
+  expect(unit.isDirty(scope)).toBe(false)
+})
+
+it("resets to new initial value", ({ scope }) => {
+  const unit = ImpulseFormUnit("2", { initial: "1" })
+
+  unit.setInitial("3")
+  expect(unit.getInput(scope)).toBe("2")
+
+  unit.reset()
+  expect(unit.getInput(scope)).toBe("3")
+  expect(unit.getInitial(scope)).toBe("3")
+  expect(unit.isDirty(scope)).toBe(false)
+})
+
+it("resets to provided initial value", ({ scope }) => {
+  const unit = ImpulseFormUnit("2", { initial: "1" })
+
+  unit.reset("3")
+  expect(unit.getInput(scope)).toBe("3")
+  expect(unit.getInitial(scope)).toBe("3")
+  expect(unit.isDirty(scope)).toBe(false)
+})
+
+it("resets custom error", ({ scope }) => {
+  const unit = ImpulseFormUnit("2", {
+    schema: z.string(),
   })
 
-  it("resets to initial value by consuming current original value with resetter", ({
-    scope,
-  }) => {
-    const value = ImpulseFormUnit("2", { initial: "1" })
+  unit.setError(["error"])
+  expect(unit.getError(scope)).toStrictEqual(["error"])
 
-    value.reset((_, current) => current)
-    expect(value.getInput(scope)).toBe("2")
-    expect(value.getInitial(scope)).toBe("2")
-    expect(value.isDirty(scope)).toBe(false)
+  unit.reset()
+  expect(unit.getError(scope)).toBeNull()
+})
+
+it("keeps isValidated=true when no validation is defined", ({ scope }) => {
+  const unit = ImpulseFormUnit("", {
+    initial: "1",
   })
 
-  it("resets to new initial value", ({ scope }) => {
-    const value = ImpulseFormUnit("2", { initial: "1" })
+  expect(unit.isValidated(scope)).toBe(true)
 
-    value.reset("3")
-    expect(value.getInput(scope)).toBe("3")
-    expect(value.getInitial(scope)).toBe("3")
-    expect(value.isDirty(scope)).toBe(false)
+  unit.reset()
+
+  expect(unit.isValidated(scope)).toBe(true)
+})
+
+it("resets isValidated when validateOn=onTouch", ({ scope }) => {
+  const unit = ImpulseFormUnit("", {
+    validateOn: "onTouch",
+    schema: z.string().min(1),
   })
 
-  it("resets custom error", ({ scope }) => {
-    const value = ImpulseFormUnit("2", { schema: z.string(), initial: "1" })
+  expect(unit.isValidated(scope)).toBe(false)
 
-    value.setError(["error"])
-    expect(value.getError(scope)).toStrictEqual(["error"])
+  unit.setTouched(true)
+  expect(unit.isValidated(scope)).toBe(true)
 
-    value.reset()
-    expect(value.getError(scope)).toBeNull()
+  unit.reset()
+  expect(unit.isValidated(scope)).toBe(false)
+})
+
+it("resets isValidated when validateOn=onChange", ({ scope }) => {
+  const unit = ImpulseFormUnit("", {
+    validateOn: "onChange",
+    schema: z.string().min(1),
   })
 
-  it("resets isValidated", ({ scope }) => {
-    const value = ImpulseFormUnit("2", { initial: "1" })
+  expect(unit.isValidated(scope)).toBe(false)
 
-    value.setTouched(true)
-    expect(value.isValidated(scope)).toBe(true)
+  unit.setInput("1")
+  expect(unit.isValidated(scope)).toBe(true)
 
-    value.reset()
-    expect(value.isValidated(scope)).toBe(false)
+  unit.reset()
+  expect(unit.isValidated(scope)).toBe(false)
+})
+
+it('resets isValidated when validateOn="onSubmit"', async ({ scope }) => {
+  const unit = ImpulseFormUnit("", {
+    validateOn: "onSubmit",
+    schema: z.string().min(1),
   })
+
+  expect(unit.isValidated(scope)).toBe(false)
+
+  await unit.submit()
+  expect(unit.isValidated(scope)).toBe(true)
+
+  unit.reset()
+  expect(unit.isValidated(scope)).toBe(false)
+})
+
+/**
+ * bugfix: ImpulseForm#reset() should respect validateOn settings #797
+ * @link https://github.com/owanturist/react-impulse/issues/797
+ */
+it("keeps isValidated when validateOn=onInit", ({ scope }) => {
+  const unit = ImpulseFormUnit("", {
+    validateOn: "onInit",
+    schema: z.string().min(1),
+  })
+
+  expect(unit.isValidated(scope)).toBe(true)
+
+  unit.reset()
+
+  expect(unit.isValidated(scope)).toBe(true)
 })


### PR DESCRIPTION

Calling `ImpulseForm#reset()` updates the `isValidated` state according to the `validateOn` strategy. Resolves [#797](https://github.com/owanturist/react-impulse/issues/797).