### PR TITLE
Respect nullable transformations in `ImpulseFormUnit`

### DIFF
--- a/.changeset/dull-animals-occur.md
+++ b/.changeset/dull-animals-occur.md
@@ -1,0 +1,5 @@
+---
+"react-impulse-form": minor
+---
+
+Do not use `NonNullable` for output and error types in `FormImpulseUnit` fabric.

--- a/.changeset/three-ideas-return.md
+++ b/.changeset/three-ideas-return.md
@@ -1,0 +1,5 @@
+---
+"react-impulse-form": minor
+---
+
+The `Result` type does not narrow nullable error type anymore.

--- a/packages/react-impulse-form/src/impulse-form-unit/impulse-form-unit.ts
+++ b/packages/react-impulse-form/src/impulse-form-unit/impulse-form-unit.ts
@@ -2,7 +2,6 @@ import { hasProperty } from "~/tools/has-property"
 import { isNull } from "~/tools/is-null"
 import { isShallowArrayEqual } from "~/tools/is-shallow-array-equal"
 import { isStrictEqual } from "~/tools/is-strict-equal"
-import type { NullOrNonNullable } from "~/tools/null-or-non-nullable"
 
 import { type Compare, Impulse, type Scope, untrack } from "../dependencies"
 import { VALIDATE_ON_TOUCH, type ValidateStrategy } from "../validate-strategy"
@@ -116,16 +115,12 @@ export interface ImpulseFormUnitValidatedOptions<
 export function ImpulseFormUnit<TInput, TError = null, TOutput = TInput>(
   input: TInput,
   options: ImpulseFormUnitValidatedOptions<TInput, TError, TOutput>,
-): ImpulseFormUnit<
-  TInput,
-  NullOrNonNullable<TError>,
-  NullOrNonNullable<TOutput>
->
+): ImpulseFormUnit<TInput, TError, TOutput>
 
 export function ImpulseFormUnit<TInput, TOutput = TInput>(
   input: TInput,
   options: ImpulseFormUnitSchemaOptions<TInput, TOutput>,
-): ImpulseFormUnit<TInput, ReadonlyArray<string>, NullOrNonNullable<TOutput>>
+): ImpulseFormUnit<TInput, ReadonlyArray<string>, TOutput>
 
 export function ImpulseFormUnit<TInput, TError = null>(
   input: TInput,

--- a/packages/react-impulse-form/src/index.ts
+++ b/packages/react-impulse-form/src/index.ts
@@ -4,6 +4,6 @@ export * from "./impulse-form-unit"
 export * from "./impulse-form-shape"
 export * from "./impulse-form-list"
 
-export * from "./zod-like-schema"
+export type * from "./result"
+export type * from "./zod-like-schema"
 export type { ValidateStrategy } from "./validate-strategy"
-export type { Result } from "./result"

--- a/packages/react-impulse-form/src/result.ts
+++ b/packages/react-impulse-form/src/result.ts
@@ -1,3 +1,1 @@
-export type Result<TError, TData> = [TError] extends [null]
-  ? [null, TData]
-  : [TError, null] | [null, TData]
+export type Result<TError, TData> = [TError, null] | [null, TData]

--- a/tools/null-or-non-nullable.ts
+++ b/tools/null-or-non-nullable.ts
@@ -1,3 +1,0 @@
-export type NullOrNonNullable<T> = [T, null] extends [null, T]
-  ? null
-  : NonNullable<T>


### PR DESCRIPTION
Do not use `NonNullable` for output and error types in `FormImpulseUnit` fabric.

---

The `Result` type does not narrow nullable error type anymore.

---

Resolves #874 