### PR TITLE
Add `ImpulseFormUnitTransformedOptions`

### DIFF
--- a/.changeset/hot-moments-fry.md
+++ b/.changeset/hot-moments-fry.md
@@ -1,0 +1,5 @@
+---
+"react-impulse-form": minor
+---
+
+Introduce `transform` option to `ImpulseFormUnit` fabric allowing to transform the form output without introducing a validation error.

--- a/packages/react-impulse-form/src/impulse-form-unit/impulse-form-unit-transformer.ts
+++ b/packages/react-impulse-form/src/impulse-form-unit/impulse-form-unit-transformer.ts
@@ -1,0 +1,3 @@
+export type ImpulseFormUnitTransformer<TInput, TOutput> = (
+  input: TInput,
+) => TOutput

--- a/packages/react-impulse-form/src/impulse-form-unit/index.ts
+++ b/packages/react-impulse-form/src/impulse-form-unit/index.ts
@@ -2,6 +2,7 @@ export * from "./impulse-form-unit"
 export * from "./is-impulse-form-unit"
 
 export type * from "./impulse-form-unit-validator"
+export type * from "./impulse-form-unit-transformer"
 
 export type * from "./impulse-form-unit-error-setter"
 export type * from "./impulse-form-unit-flag-setter"

--- a/packages/react-impulse-form/tests/impulse-form-unit/impulse-form-unit.spec.ts
+++ b/packages/react-impulse-form/tests/impulse-form-unit/impulse-form-unit.spec.ts
@@ -14,6 +14,37 @@ it("creates ImpulseFormUnit without validation", ({ scope }) => {
   expect(value.getOutput(scope)).toBe(1)
 })
 
+it("creates ImpulseFormUnit with same type transformer", ({ scope }) => {
+  const value = ImpulseFormUnit("", {
+    transform: (input) => input.trim(),
+  })
+
+  expectTypeOf(value).toEqualTypeOf<ImpulseFormUnit<string>>()
+  expectTypeOf(value).toEqualTypeOf<ImpulseFormUnit<string, null, string>>()
+
+  expect(value.getInput(scope)).toBe("")
+  expect(value.getOutput(scope)).toBe("")
+
+  value.setInput(" 123 ")
+  expect(value.getInput(scope)).toBe(" 123 ")
+  expect(value.getOutput(scope)).toBe("123")
+})
+
+it("creates ImpulseFormUnit with converting type transformer", ({ scope }) => {
+  const value = ImpulseFormUnit("", {
+    transform: (input) => input.trim().length,
+  })
+
+  expectTypeOf(value).toEqualTypeOf<ImpulseFormUnit<string, null, number>>()
+
+  expect(value.getInput(scope)).toBe("")
+  expect(value.getOutput(scope)).toBe(0)
+
+  value.setInput(" 123 ")
+  expect(value.getInput(scope)).toBe(" 123 ")
+  expect(value.getOutput(scope)).toBe(3)
+})
+
 it("creates ImpulseFormUnit with same type validator", ({ scope }) => {
   const value = ImpulseFormUnit("", {
     validateOn: "onInit",

--- a/packages/react-impulse-form/tests/impulse-form-unit/is-validated.spec.ts
+++ b/packages/react-impulse-form/tests/impulse-form-unit/is-validated.spec.ts
@@ -50,6 +50,38 @@ it("matches the type signature", () => {
   }>()
 })
 
+it("returns true on init without transform, validate, or schema", ({
+  scope,
+}) => {
+  const unit = ImpulseFormUnit("y")
+
+  expect(unit.isValidated(scope)).toBe(true)
+})
+
+it("returns true on init when transform", ({ scope }) => {
+  const unit = ImpulseFormUnit("y", {
+    transform: (input) => input,
+  })
+
+  expect(unit.isValidated(scope)).toBe(true)
+})
+
+it("returns false on init when validate", ({ scope }) => {
+  const unit = ImpulseFormUnit("y", {
+    validate: (input) => [null, input],
+  })
+
+  expect(unit.isValidated(scope)).toBe(false)
+})
+
+it("returns false on init when schema", ({ scope }) => {
+  const unit = ImpulseFormUnit("y", {
+    schema: z.string(),
+  })
+
+  expect(unit.isValidated(scope)).toBe(false)
+})
+
 describe.each([
   ["(scope)", isValidatedDefault],
   ["(scope, (concise) => concise)", isValidatedConcise],

--- a/packages/react-impulse-form/tests/impulse-form-unit/set-transform.spec.ts
+++ b/packages/react-impulse-form/tests/impulse-form-unit/set-transform.spec.ts
@@ -1,0 +1,53 @@
+import { ImpulseFormUnit } from "packages/react-impulse-form/src"
+import z from "zod"
+
+it("sets the transformer", ({ scope }) => {
+  const unit = ImpulseFormUnit("hi")
+
+  expect(unit.getOutput(scope)).toBe("hi")
+
+  unit.setTransform((input) => input + ".")
+  expect(unit.getOutput(scope)).toBe("hi.")
+})
+
+it("overrides a transformer", ({ scope }) => {
+  const unit = ImpulseFormUnit("hi", {
+    transform: (input) => input + ".",
+  })
+
+  expect(unit.getOutput(scope)).toBe("hi.")
+
+  unit.setTransform((input) => input + "!")
+  expect(unit.getOutput(scope)).toBe("hi!")
+
+  unit.setTransform((input) => input + "?")
+  expect(unit.getOutput(scope)).toBe("hi?")
+})
+
+it("overrides schema", ({ scope }) => {
+  const unit = ImpulseFormUnit("hi", {
+    schema: z.string().transform((input) => input.length),
+  })
+
+  expect(unit.getOutput(scope)).toBe(2)
+
+  unit.setTransform((input) => input.length + 1)
+  expect(unit.getOutput(scope)).toBe(3)
+})
+
+it("overrides validate", ({ scope }) => {
+  const unit = ImpulseFormUnit<string, string, number>("hi", {
+    validate: (input) => {
+      if (input.length < 1) {
+        return ["Input is too short", null]
+      }
+
+      return [null, input.length]
+    },
+  })
+
+  expect(unit.getOutput(scope)).toBe(2)
+
+  unit.setTransform((input) => input.length + 1)
+  expect(unit.getOutput(scope)).toBe(3)
+})


### PR DESCRIPTION

Introduce `transform` option to `ImpulseFormUnit` fabric allowing to transform the form output without introducing a validation error.