### PR TITLE
Implement `ImpulseForm#onFocusWhenInvalid`

### DIFF
--- a/.changeset/olive-glasses-dress.md
+++ b/.changeset/olive-glasses-dress.md
@@ -1,0 +1,5 @@
+---
+"react-impulse-form": minor
+---
+
+Added `ImpulseForm#onFocusWhenInvalid` so it is now possible to attache a listener to any form and not only `ImpulseFormUnit`. It focuses the furthest first invalid field with `onFocus` listener attached to it.

--- a/.changeset/olive-glasses-dress.md
+++ b/.changeset/olive-glasses-dress.md
@@ -2,4 +2,4 @@
 "react-impulse-form": minor
 ---
 
-Added `ImpulseForm#onFocusWhenInvalid` so it is now possible to attache a listener to any form and not only `ImpulseFormUnit`. It focuses the furthest first invalid field with `onFocus` listener attached to it.
+The `ImpulseForm#onFocusWhenInvalid` method has been implemented, so it is now possible to attach a listener to any form, not only `ImpulseFormUnit`. It focuses on the furthest first invalid field with the `onFocus` listener attached to it.

--- a/packages/react-impulse-form/src/impulse-form-list/_impulse-form-list.ts
+++ b/packages/react-impulse-form/src/impulse-form-list/_impulse-form-list.ts
@@ -82,7 +82,7 @@ export class ImpulseFormList<
     })
   }
 
-  protected _submitWith(
+  protected override _submitWith(
     output: ImpulseFormListOutput<TElement>,
   ): ReadonlyArray<void | Promise<unknown>> {
     const promises = untrack(this._elements).flatMap((element, index) => {
@@ -92,7 +92,7 @@ export class ImpulseFormList<
     return [...super._submitWith(output), ...promises]
   }
 
-  protected _getFocusFirstInvalid(scope: Scope): VoidFunction | null {
+  protected override _getFocusFirstInvalid(scope: Scope): VoidFunction | null {
     for (const element of this._elements.getValue(scope)) {
       const focus = ImpulseForm._getFocusFirstInvalid(scope, element)
 
@@ -101,7 +101,7 @@ export class ImpulseFormList<
       }
     }
 
-    return this._getFocusInvalid(scope)
+    return super._getFocusFirstInvalid(scope)
   }
 
   protected _childOf(parent: null | ImpulseForm): ImpulseFormList<TElement> {

--- a/packages/react-impulse-form/src/impulse-form-list/_impulse-form-list.ts
+++ b/packages/react-impulse-form/src/impulse-form-list/_impulse-form-list.ts
@@ -92,9 +92,9 @@ export class ImpulseFormList<
     return [...super._submitWith(output), ...promises]
   }
 
-  protected _getFocusFirstInvalidValue(): VoidFunction | null {
+  protected _getFocusFirstInvalid(): VoidFunction | null {
     for (const element of untrack(this._elements)) {
-      const focus = ImpulseForm._getFocusFirstInvalidValue(element)
+      const focus = ImpulseForm._getFocusFirstInvalid(element)
 
       if (focus != null) {
         return focus

--- a/packages/react-impulse-form/src/impulse-form-list/_impulse-form-list.ts
+++ b/packages/react-impulse-form/src/impulse-form-list/_impulse-form-list.ts
@@ -92,9 +92,9 @@ export class ImpulseFormList<
     return [...super._submitWith(output), ...promises]
   }
 
-  protected _getFocusFirstInvalid(): VoidFunction | null {
-    for (const element of untrack(this._elements)) {
-      const focus = ImpulseForm._getFocusFirstInvalid(element)
+  protected _getFocusFirstInvalid(scope: Scope): VoidFunction | null {
+    for (const element of this._elements.getValue(scope)) {
+      const focus = ImpulseForm._getFocusFirstInvalid(scope, element)
 
       if (focus != null) {
         return focus

--- a/packages/react-impulse-form/src/impulse-form-list/_impulse-form-list.ts
+++ b/packages/react-impulse-form/src/impulse-form-list/_impulse-form-list.ts
@@ -101,7 +101,7 @@ export class ImpulseFormList<
       }
     }
 
-    return null
+    return this._getFocusInvalid(scope)
   }
 
   protected _childOf(parent: null | ImpulseForm): ImpulseFormList<TElement> {

--- a/packages/react-impulse-form/src/impulse-form-shape/_impulse-form-shape.ts
+++ b/packages/react-impulse-form/src/impulse-form-shape/_impulse-form-shape.ts
@@ -91,10 +91,10 @@ export class ImpulseFormShape<
     return [...super._submitWith(output), ...promises]
   }
 
-  protected _getFocusFirstInvalidValue(): VoidFunction | null {
+  protected _getFocusFirstInvalid(): VoidFunction | null {
     for (const field of Object.values(this.fields)) {
       if (isImpulseForm(field)) {
-        const focus = ImpulseForm._getFocusFirstInvalidValue(field)
+        const focus = ImpulseForm._getFocusFirstInvalid(field)
 
         if (focus != null) {
           return focus

--- a/packages/react-impulse-form/src/impulse-form-shape/_impulse-form-shape.ts
+++ b/packages/react-impulse-form/src/impulse-form-shape/_impulse-form-shape.ts
@@ -102,7 +102,7 @@ export class ImpulseFormShape<
       }
     }
 
-    return null
+    return this._getFocusInvalid(scope)
   }
 
   protected _childOf(parent: null | ImpulseForm): ImpulseFormShape<TFields> {

--- a/packages/react-impulse-form/src/impulse-form-shape/_impulse-form-shape.ts
+++ b/packages/react-impulse-form/src/impulse-form-shape/_impulse-form-shape.ts
@@ -77,7 +77,7 @@ export class ImpulseFormShape<
     return acc
   }
 
-  protected _submitWith(
+  protected override _submitWith(
     output: ImpulseFormShapeOutput<TFields>,
   ): ReadonlyArray<void | Promise<unknown>> {
     const promises = Object.entries(this.fields).flatMap(([key, field]) => {
@@ -91,7 +91,7 @@ export class ImpulseFormShape<
     return [...super._submitWith(output), ...promises]
   }
 
-  protected _getFocusFirstInvalid(scope: Scope): VoidFunction | null {
+  protected override _getFocusFirstInvalid(scope: Scope): VoidFunction | null {
     for (const field of Object.values(this.fields)) {
       if (isImpulseForm(field)) {
         const focus = ImpulseForm._getFocusFirstInvalid(scope, field)
@@ -102,7 +102,7 @@ export class ImpulseFormShape<
       }
     }
 
-    return this._getFocusInvalid(scope)
+    return super._getFocusFirstInvalid(scope)
   }
 
   protected _childOf(parent: null | ImpulseForm): ImpulseFormShape<TFields> {

--- a/packages/react-impulse-form/src/impulse-form-shape/_impulse-form-shape.ts
+++ b/packages/react-impulse-form/src/impulse-form-shape/_impulse-form-shape.ts
@@ -91,10 +91,10 @@ export class ImpulseFormShape<
     return [...super._submitWith(output), ...promises]
   }
 
-  protected _getFocusFirstInvalid(): VoidFunction | null {
+  protected _getFocusFirstInvalid(scope: Scope): VoidFunction | null {
     for (const field of Object.values(this.fields)) {
       if (isImpulseForm(field)) {
-        const focus = ImpulseForm._getFocusFirstInvalid(field)
+        const focus = ImpulseForm._getFocusFirstInvalid(scope, field)
 
         if (focus != null) {
           return focus

--- a/packages/react-impulse-form/src/impulse-form-unit/_impulse-form-unit.ts
+++ b/packages/react-impulse-form/src/impulse-form-unit/_impulse-form-unit.ts
@@ -3,13 +3,7 @@ import { isNull } from "~/tools/is-null"
 import { params } from "~/tools/params"
 import { resolveSetter } from "~/tools/setter"
 
-import {
-  type Compare,
-  Impulse,
-  type Scope,
-  batch,
-  untrack,
-} from "../dependencies"
+import { type Compare, Impulse, type Scope, batch } from "../dependencies"
 import { ImpulseForm } from "../impulse-form"
 import type { Result } from "../result"
 import {
@@ -139,10 +133,9 @@ export class ImpulseFormUnit<
     return [null, null]
   }
 
-  protected _getFocusFirstInvalid(): null | VoidFunction {
-    const error = this._onFocus._isEmpty()
-      ? null
-      : untrack((scope) => this.getError(scope))
+  protected _getFocusFirstInvalid(scope: Scope): null | VoidFunction {
+    // ignore if the focus handlers are not set
+    const error = this._onFocus._isEmpty() ? null : this.getError(scope)
 
     if (error == null) {
       return null

--- a/packages/react-impulse-form/src/impulse-form-unit/_impulse-form-unit.ts
+++ b/packages/react-impulse-form/src/impulse-form-unit/_impulse-form-unit.ts
@@ -10,7 +10,6 @@ import {
   batch,
   untrack,
 } from "../dependencies"
-import { Emitter } from "../emitter"
 import { ImpulseForm } from "../impulse-form"
 import type { Result } from "../result"
 import {
@@ -57,8 +56,6 @@ export class ImpulseFormUnit<
   "error.schema": null | TError
   "error.schema.verbose": null | TError
 }> {
-  private readonly _onFocus = new Emitter<[error: TError]>()
-
   private readonly _validated = Impulse(false)
 
   public constructor(
@@ -142,7 +139,7 @@ export class ImpulseFormUnit<
     return [null, null]
   }
 
-  protected _getFocusFirstInvalidValue(): null | VoidFunction {
+  protected _getFocusFirstInvalid(): null | VoidFunction {
     const error = this._onFocus._isEmpty()
       ? null
       : untrack((scope) => this.getError(scope))
@@ -401,9 +398,5 @@ export class ImpulseFormUnit<
         this._initialSource.getValue(scope)?.setInitial(setter)
       }
     })
-  }
-
-  public onFocusWhenInvalid(onFocus: (error: TError) => void): VoidFunction {
-    return this._onFocus._subscribe(onFocus)
   }
 }

--- a/packages/react-impulse-form/src/impulse-form-unit/_impulse-form-unit.ts
+++ b/packages/react-impulse-form/src/impulse-form-unit/_impulse-form-unit.ts
@@ -134,16 +134,7 @@ export class ImpulseFormUnit<
   }
 
   protected _getFocusFirstInvalid(scope: Scope): null | VoidFunction {
-    // ignore if the focus handlers are not set
-    const error = this._onFocus._isEmpty() ? null : this.getError(scope)
-
-    if (error == null) {
-      return null
-    }
-
-    return () => {
-      this._onFocus._emit(error)
-    }
+    return this._getFocusInvalid(scope)
   }
 
   // TODO add tests against _validated when cloning

--- a/packages/react-impulse-form/src/impulse-form-unit/_impulse-form-unit.ts
+++ b/packages/react-impulse-form/src/impulse-form-unit/_impulse-form-unit.ts
@@ -133,10 +133,6 @@ export class ImpulseFormUnit<
     return [null, null]
   }
 
-  protected _getFocusFirstInvalid(scope: Scope): null | VoidFunction {
-    return this._getFocusInvalid(scope)
-  }
-
   // TODO add tests against _validated when cloning
   protected _childOf(
     parent: null | ImpulseForm,

--- a/packages/react-impulse-form/src/impulse-form/impulse-form.ts
+++ b/packages/react-impulse-form/src/impulse-form/impulse-form.ts
@@ -37,10 +37,10 @@ export abstract class ImpulseForm<
     return form._submitWith(output)
   }
 
-  protected static _getFocusFirstInvalidValue(
+  protected static _getFocusFirstInvalid(
     form: ImpulseForm,
   ): null | VoidFunction {
-    return form._getFocusFirstInvalidValue()
+    return form._getFocusFirstInvalid()
   }
 
   protected static _setValidated(
@@ -65,6 +65,8 @@ export abstract class ImpulseForm<
   // necessary for type inference
   protected readonly _params?: TParams
 
+  protected readonly _onFocus = new Emitter<[error: unknown]>()
+
   private readonly _onSubmit = new Emitter<
     [output: unknown],
     void | Promise<unknown>
@@ -79,7 +81,7 @@ export abstract class ImpulseForm<
     this._root = _root ?? this
   }
 
-  protected abstract _getFocusFirstInvalidValue(): null | VoidFunction
+  protected abstract _getFocusFirstInvalid(): null | VoidFunction
 
   protected abstract _childOf(parent: null | ImpulseForm): ImpulseForm<TParams>
 
@@ -103,6 +105,12 @@ export abstract class ImpulseForm<
     output: TParams["output.schema"],
   ): ReadonlyArray<void | Promise<unknown>> {
     return this._onSubmit._emit(output)
+  }
+
+  public onFocusWhenInvalid(
+    onFocus: (error: TParams["error.schema.verbose"]) => void,
+  ): VoidFunction {
+    return this._onFocus._subscribe(onFocus)
   }
 
   public getSubmitCount(scope: Scope): number {
@@ -147,7 +155,7 @@ export abstract class ImpulseForm<
   }
 
   public focusFirstInvalid(): void {
-    this._getFocusFirstInvalidValue()?.()
+    this._getFocusFirstInvalid()?.()
   }
 
   public clone(): ImpulseForm<TParams> {

--- a/packages/react-impulse-form/src/impulse-form/impulse-form.ts
+++ b/packages/react-impulse-form/src/impulse-form/impulse-form.ts
@@ -37,9 +37,10 @@ export abstract class ImpulseForm<
   }
 
   protected static _getFocusFirstInvalid(
+    scope: Scope,
     form: ImpulseForm,
   ): null | VoidFunction {
-    return form._getFocusFirstInvalid()
+    return form._getFocusFirstInvalid(scope)
   }
 
   protected static _setValidated(
@@ -80,7 +81,7 @@ export abstract class ImpulseForm<
     this._root = _root ?? this
   }
 
-  protected abstract _getFocusFirstInvalid(): null | VoidFunction
+  protected abstract _getFocusFirstInvalid(scope: Scope): null | VoidFunction
 
   protected abstract _childOf(parent: null | ImpulseForm): ImpulseForm<TParams>
 
@@ -154,7 +155,9 @@ export abstract class ImpulseForm<
   }
 
   public focusFirstInvalid(): void {
-    this._getFocusFirstInvalid()?.()
+    batch((scope) => {
+      this._getFocusFirstInvalid(scope)?.()
+    })
   }
 
   public clone(): ImpulseForm<TParams> {

--- a/packages/react-impulse-form/src/impulse-form/impulse-form.ts
+++ b/packages/react-impulse-form/src/impulse-form/impulse-form.ts
@@ -1,7 +1,6 @@
 import { isDefined } from "~/tools/is-defined"
 import { isNull } from "~/tools/is-null"
 import { isTruthy } from "~/tools/is-truthy"
-import { isUndefined } from "~/tools/is-undefined"
 
 import { Impulse, type Scope, batch, untrack } from "../dependencies"
 import { Emitter } from "../emitter"
@@ -143,7 +142,7 @@ export abstract class ImpulseForm<
       return undefined
     })
 
-    if (isUndefined(promises)) {
+    if (!promises) {
       this._root.focusFirstInvalid()
     } else if (promises.length > 0) {
       this._root._submittingCount.setValue((count) => count + 1)

--- a/packages/react-impulse-form/src/impulse-form/impulse-form.ts
+++ b/packages/react-impulse-form/src/impulse-form/impulse-form.ts
@@ -65,7 +65,7 @@ export abstract class ImpulseForm<
   // necessary for type inference
   protected readonly _params?: TParams
 
-  protected readonly _onFocus = new Emitter<[error: unknown]>()
+  private readonly _onFocus = new Emitter<[error: unknown]>()
 
   private readonly _onSubmit = new Emitter<
     [output: unknown],
@@ -105,6 +105,19 @@ export abstract class ImpulseForm<
     output: TParams["output.schema"],
   ): ReadonlyArray<void | Promise<unknown>> {
     return this._onSubmit._emit(output)
+  }
+
+  protected _getFocusInvalid(scope: Scope): null | VoidFunction {
+    // ignore if the focus handlers are not set
+    const error = this._onFocus._isEmpty() ? null : this.getError(scope)
+
+    if (error == null) {
+      return null
+    }
+
+    return () => {
+      this._onFocus._emit(error)
+    }
   }
 
   public onFocusWhenInvalid(

--- a/packages/react-impulse-form/src/impulse-form/impulse-form.ts
+++ b/packages/react-impulse-form/src/impulse-form/impulse-form.ts
@@ -81,8 +81,6 @@ export abstract class ImpulseForm<
     this._root = _root ?? this
   }
 
-  protected abstract _getFocusFirstInvalid(scope: Scope): null | VoidFunction
-
   protected abstract _childOf(parent: null | ImpulseForm): ImpulseForm<TParams>
 
   protected abstract _setInitial(
@@ -107,7 +105,7 @@ export abstract class ImpulseForm<
     return this._onSubmit._emit(output)
   }
 
-  protected _getFocusInvalid(scope: Scope): null | VoidFunction {
+  protected _getFocusFirstInvalid(scope: Scope): null | VoidFunction {
     // ignore if the focus handlers are not set
     const error = this._onFocus._isEmpty() ? null : this.getError(scope)
 

--- a/packages/react-impulse-form/tests/impulse-form-list/focus-first-invalid.spec.ts
+++ b/packages/react-impulse-form/tests/impulse-form-list/focus-first-invalid.spec.ts
@@ -84,3 +84,17 @@ it("calls the only invalid", () => {
   expect(listener_1).toHaveBeenCalledExactlyOnceWith(["error1"])
   expect(listener_2).not.toHaveBeenCalled()
 })
+
+it("does not focus invalid without listener", ({ scope }) => {
+  const form = ImpulseFormList([
+    ImpulseFormUnit(1, { error: "err-1" }),
+    ImpulseFormUnit(2, { error: "err-2" }),
+  ])
+
+  const listener_1 = vi.fn()
+
+  form.getElements(scope).at(1)?.onFocusWhenInvalid(listener_1)
+
+  form.focusFirstInvalid()
+  expect(listener_1).toHaveBeenCalledExactlyOnceWith("err-2")
+})

--- a/packages/react-impulse-form/tests/impulse-form-list/focus-first-invalid.spec.ts
+++ b/packages/react-impulse-form/tests/impulse-form-list/focus-first-invalid.spec.ts
@@ -98,3 +98,83 @@ it("does not focus invalid without listener", ({ scope }) => {
   form.focusFirstInvalid()
   expect(listener_1).toHaveBeenCalledExactlyOnceWith("err-2")
 })
+
+describe("with onFocusWhenInvalid()", () => {
+  it("does nothing when elements are empty", () => {
+    const form = ImpulseFormList([])
+    const listener_0 = vi.fn()
+
+    form.onFocusWhenInvalid(listener_0)
+    form.focusFirstInvalid()
+    expect(listener_0).not.toHaveBeenCalled()
+  })
+
+  it("does not call a listener when elements are not validated", () => {
+    const form = ImpulseFormList([
+      ImpulseFormUnit("", {
+        schema: z.string(),
+      }),
+    ])
+
+    const listener_0 = vi.fn()
+
+    form.onFocusWhenInvalid(listener_0)
+    form.focusFirstInvalid()
+    expect(listener_0).not.toHaveBeenCalled()
+  })
+
+  it("does not call a listener when elements are valid", () => {
+    const form = ImpulseFormList([
+      ImpulseFormUnit("valid", {
+        validateOn: "onInit",
+        schema: z.string().min(2),
+      }),
+    ])
+
+    const listener_0 = vi.fn()
+
+    form.onFocusWhenInvalid(listener_0)
+    form.focusFirstInvalid()
+    expect(listener_0).not.toHaveBeenCalled()
+  })
+
+  it("calls a listener when an element is not valid", () => {
+    const form = ImpulseFormList([
+      ImpulseFormUnit("", {
+        validateOn: "onInit",
+        schema: z.string().min(2),
+      }),
+    ])
+
+    const listener_0 = vi.fn()
+
+    form.onFocusWhenInvalid(listener_0)
+    form.focusFirstInvalid()
+    expect(listener_0).toHaveBeenCalledExactlyOnceWith([
+      ["String must contain at least 2 character(s)"],
+    ])
+  })
+
+  it("does not call a listener when an element is invalid and has own listener", ({
+    scope,
+  }) => {
+    const form = ImpulseFormList([
+      ImpulseFormUnit("", {
+        validateOn: "onInit",
+        schema: z.string().min(2),
+      }),
+    ])
+
+    const listener_0 = vi.fn()
+    const listener_1 = vi.fn()
+
+    form.onFocusWhenInvalid(listener_0)
+    form.getElements(scope).at(0)?.onFocusWhenInvalid(listener_1)
+    form.focusFirstInvalid()
+
+    expect(listener_0).not.toHaveBeenCalled()
+    expect(listener_1).toHaveBeenCalledExactlyOnceWith([
+      "String must contain at least 2 character(s)",
+    ])
+  })
+})

--- a/packages/react-impulse-form/tests/impulse-form-shape/focus-first-invalid.spec.ts
+++ b/packages/react-impulse-form/tests/impulse-form-shape/focus-first-invalid.spec.ts
@@ -168,3 +168,81 @@ describe("fields.*.focusFirstInvalid()", () => {
     expect(listener_3_2).not.toHaveBeenCalled()
   })
 })
+
+describe("with onFocusWhenInvalid()", () => {
+  it("does nothing when fields are empty", () => {
+    const form = ImpulseFormShape({})
+    const listener_0 = vi.fn()
+
+    form.onFocusWhenInvalid(listener_0)
+    form.focusFirstInvalid()
+    expect(listener_0).not.toHaveBeenCalled()
+  })
+
+  it("does not call a listener when fields are not validated", () => {
+    const form = ImpulseFormShape({
+      _1: ImpulseFormUnit("", {
+        schema: z.string(),
+      }),
+    })
+
+    const listener_0 = vi.fn()
+
+    form.onFocusWhenInvalid(listener_0)
+    form.focusFirstInvalid()
+    expect(listener_0).not.toHaveBeenCalled()
+  })
+
+  it("does not call a listener when fields are valid", () => {
+    const form = ImpulseFormShape({
+      _1: ImpulseFormUnit("valid", {
+        validateOn: "onInit",
+        schema: z.string().min(2),
+      }),
+    })
+
+    const listener_0 = vi.fn()
+
+    form.onFocusWhenInvalid(listener_0)
+    form.focusFirstInvalid()
+    expect(listener_0).not.toHaveBeenCalled()
+  })
+
+  it("calls a listener when a field is not valid", () => {
+    const form = ImpulseFormShape({
+      _1: ImpulseFormUnit("", {
+        validateOn: "onInit",
+        schema: z.string().min(2),
+      }),
+    })
+
+    const listener_0 = vi.fn()
+
+    form.onFocusWhenInvalid(listener_0)
+    form.focusFirstInvalid()
+    expect(listener_0).toHaveBeenCalledExactlyOnceWith({
+      _1: ["String must contain at least 2 character(s)"],
+    })
+  })
+
+  it("does not call a listener when a field is invalid and has own listener", () => {
+    const form = ImpulseFormShape({
+      _1: ImpulseFormUnit("", {
+        validateOn: "onInit",
+        schema: z.string().min(2),
+      }),
+    })
+
+    const listener_0 = vi.fn()
+    const listener_1 = vi.fn()
+
+    form.onFocusWhenInvalid(listener_0)
+    form.fields._1.onFocusWhenInvalid(listener_1)
+    form.focusFirstInvalid()
+
+    expect(listener_0).not.toHaveBeenCalled()
+    expect(listener_1).toHaveBeenCalledExactlyOnceWith([
+      "String must contain at least 2 character(s)",
+    ])
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     "jsx": "react",
     "types": ["vitest/globals"],
     "verbatimModuleSyntax": true,
+    "noImplicitOverride": true,
     "baseUrl": ".",
     "paths": {
       "~/tools/*": ["./tools/*"]


### PR DESCRIPTION
The `ImpulseForm#onFocusWhenInvalid` method has been implemented, so it is now possible to attach a listener to any form, not only `ImpulseFormUnit`. It focuses on the furthest first invalid field with the `onFocus` listener attached to it.

---

Resolves #852 