### PR TITLE
Minify functions and classes in dist files

### DIFF
--- a/.changeset/wise-monkeys-heal.md
+++ b/.changeset/wise-monkeys-heal.md
@@ -1,0 +1,6 @@
+---
+"react-impulse": patch
+"react-impulse-form": patch
+---
+
+Minify class and function names in production builds.

--- a/packages/react-impulse/src/scope-emitter.ts
+++ b/packages/react-impulse/src/scope-emitter.ts
@@ -24,7 +24,7 @@ export class ScopeEmitterQueue {
           /**
            * Emit immediately so `DerivedImpulse` utilizes the compare function to either:
            * 1. NOT CHANGED: resubscribe to sources and set its._version = emitter._version
-           * 2. CHANGED: _push'es its._emitters so they end up here either emitting (DirectImpulse) or scheduling (DerivedImpulse).
+           * 2. CHANGED: _push'es its._emitters so they end up here either emitting (DerivedImpulse) or scheduling (DirectImpulse).
            */
           emitter._emit()
         } else {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,8 +10,8 @@ export default defineConfig({
   terserOptions: {
     mangle: {
       module: false,
-      keep_classnames: true,
-      keep_fnames: true,
+      keep_classnames: false,
+      keep_fnames: false,
       properties: {
         regex: /^_[^_]\w+[^_]$/,
         // @ts-expect-error undocumented, but it specifies how to mangle Impulse's properties


### PR DESCRIPTION
The `build:minified` script used to produce JS with everything minified except the functions/classes names. The idea was to delegate this operation over user-side builders but turns out it screws the bundle size estimation during builds.