### PR TITLE
Extend Impulse(getter, options?) factory to accept `ReadableImpulse` as `getter`

### DIFF
--- a/.changeset/clean-doors-fold.md
+++ b/.changeset/clean-doors-fold.md
@@ -1,0 +1,14 @@
+---
+"react-impulse": minor
+---
+
+Extend `Impulse(getter, options?)` by allowing `getter` to be a `ReadableImpulse<T>`:
+
+```dart
+Impulse<T>(
+  getter: ReadableImpulse<T> | ((scope: Scope) => T),
+  options?: ImpulseOptions<T>,
+): ReadonlyImpulse<T>
+```
+
+Resolves [#895](https://github.com/owanturist/react-impulse/issues/895)

--- a/packages/react-impulse/README.md
+++ b/packages/react-impulse/README.md
@@ -189,7 +189,7 @@ const Counter: React.FC = () => {
 
 ```dart
 Impulse<T>(
-  getter: (scope: Scope) => T,
+  getter: ReadableImpulse<T> | ((scope: Scope) => T),
   options?: ImpulseOptions<T>,
 ): ReadonlyImpulse<T>
 

--- a/packages/react-impulse/src/impulse.ts
+++ b/packages/react-impulse/src/impulse.ts
@@ -29,14 +29,14 @@ export function Impulse<T = undefined>(): Impulse<undefined | T>
  * Creates a new derived ReadonlyImpulse.
  * A derived Impulse is an Impulse that keeps the derived value in memory and updates it whenever the source value changes.
  *
- * @param getter a function to read the derived value from a source.
+ * @param getter either anything that implements the `ReadableImpulse` interface or a function to read the derived value from the source.
  * @param options optional `ImpulseOptions`.
  * @param options.compare when not defined or `null` then `Object.is` applies as a fallback.
  *
  * @version 3.0.0
  */
 export function Impulse<T>(
-  getter: (scope: Scope) => T,
+  getter: ReadableImpulse<T> | ((scope: Scope) => T),
   options?: ImpulseOptions<T>,
 ): ReadonlyImpulse<T>
 


### PR DESCRIPTION
Extend `Impulse(getter, options?)` by allowing `getter` to be a `ReadableImpulse<T>`:

```dart
Impulse<T>(
  getter: ReadableImpulse<T> | ((scope: Scope) => T),
  options?: ImpulseOptions<T>,
): ReadonlyImpulse<T>
```

Resolves [#895](https://github.com/owanturist/react-impulse/issues/895)