### PR TITLE
Unskip the `test-react-impulse-support` job

### DIFF
--- a/.changeset/huge-streets-follow.md
+++ b/.changeset/huge-streets-follow.md
@@ -1,0 +1,5 @@
+---
+"react-impulse-form": minor
+---
+
+Bump peer dependency `react-impulse` to `^3.0.3`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [3.0.1]
+        version: [3.0.2]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [3.0.3]
+        version: [3.0.1]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [3.0.2]
+        version: [3.0.3]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,6 @@ jobs:
         run: pnpm typecheck
 
   test-react-impulse-support:
-    # skip the job while the 3.0.0 is not released
-    if: false
     name: Run tests against support react-impulse
     runs-on: ubuntu-latest
     strategy:
@@ -165,13 +163,7 @@ jobs:
   release:
     name: Release on npm
     runs-on: ubuntu-latest
-    needs: [
-        checks,
-        test-dist,
-        test-react-support,
-        # the job is skipped for now
-        # test-react-impulse-support
-      ]
+    needs: [checks, test-dist, test-react-support, test-react-impulse-support]
     # prevents this action from running on forks and only on pushes
     if: ${{ github.repository_owner == 'owanturist' && github.event_name == 'push' }}
     concurrency: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [3.0.0]
+        version: [3.0.3]
 
     steps:
       - name: Checkout repository

--- a/packages/react-impulse-form/package.json
+++ b/packages/react-impulse-form/package.json
@@ -32,7 +32,7 @@
     "build": "tsup --config ../../tsup.config.ts"
   },
   "peerDependencies": {
-    "react-impulse": "^3.0.0"
+    "react-impulse": "^3.0.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.4",


### PR DESCRIPTION
Bump peer dependency `react-impulse` to `^3.0.3`.